### PR TITLE
fix: Enable CORS in backend

### DIFF
--- a/pokemon-battle-backend/index.js
+++ b/pokemon-battle-backend/index.js
@@ -1,5 +1,6 @@
 const express = require('express');
 const bodyParser = require('body-parser');
+const cors = require('cors'); // Added CORS require
 const { getPokemonDetails } = require('./pokemonData'); // Import Pokemon data handler
 
 const app = express();
@@ -8,6 +9,8 @@ const port = process.env.PORT || 3000;
 // In-memory store for game states
 const games = {};
 
+// Middleware
+app.use(cors()); // Enabled CORS for all origins
 app.use(bodyParser.json());
 
 // Route to create a new game

--- a/pokemon-battle-backend/package.json
+++ b/pokemon-battle-backend/package.json
@@ -8,8 +8,9 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "dependencies": {
-    "express": "^4.17.1",
-    "body-parser": "^1.19.0"
+    "body-parser": "^1.19.0",
+    "cors": "^2.8.5",
+    "express": "^4.17.1"
   },
   "author": "",
   "license": "ISC"


### PR DESCRIPTION
Installs the 'cors' package and enables it in the Express application to allow cross-origin requests from the frontend.

This resolves issues where the browser's Same-Origin Policy would block the frontend from receiving responses from the backend. CORS is now enabled for all origins with default settings.