### PR TITLE
feat: Implement real-time game updates via WebSockets

### DIFF
--- a/pokemon-battle-backend/index.js
+++ b/pokemon-battle-backend/index.js
@@ -1,227 +1,331 @@
 const express = require('express');
 const bodyParser = require('body-parser');
-const cors = require('cors'); // Added CORS require
-const { getPokemonDetails } = require('./pokemonData'); // Import Pokemon data handler
+const cors = require('cors');
+const { getPokemonDetails } = require('./pokemonData');
+const http = require('http');
+const WebSocket = require('ws');
+const url = require('url');
 
 const app = express();
 const port = process.env.PORT || 3000;
 
-// In-memory store for game states
 const games = {};
 
-// Middleware
-app.use(cors()); // Enabled CORS for all origins
+app.use(cors());
 app.use(bodyParser.json());
 
-// Route to create a new game
-app.post('/game', (req, res) => {
-    const gameId = `game_${Date.now()}`;
-    games[gameId] = {
-        id: gameId,
-        players: [],
-        state: 'waiting_for_players', // Possible states: waiting_for_players, selecting_pokemon, battle, finished
-        turn: null,
-        winner: null,
-    };
-    console.log(`[Game ${gameId}] Created`);
-    res.status(201).json({ gameId, message: 'Game created successfully. Waiting for players to join.' });
+const server = http.createServer(app);
+const wss = new WebSocket.Server({ server });
+
+// Helper function to sanitize game state for broadcasting (remove ws objects)
+const getSanitizedGameState = (gameId) => {
+    if (!games[gameId]) return null;
+    const game = games[gameId];
+    // Create a deep copy to avoid mutating the original 'ws' property on players
+    const gameCopy = JSON.parse(JSON.stringify(game));
+    gameCopy.players.forEach(p => delete p.ws); // Remove ws from the copy
+    return gameCopy;
+};
+
+// Helper function to broadcast game state to all connected clients in a game
+const broadcastGameState = (gameId) => {
+    const game = games[gameId];
+    if (!game) {
+        console.log(`[WebSocket] Broadcast: Game ${gameId} not found, cannot broadcast.`);
+        return;
+    }
+
+    const sanitizedGameState = getSanitizedGameState(gameId); // Use the modified sanitizer
+    if (!sanitizedGameState) {
+        console.log(`[WebSocket] Broadcast: Sanitized game state for ${gameId} is null, cannot broadcast.`);
+        return;
+    }
+
+    console.log(`[WebSocket] Broadcasting game state for game ${gameId} to players.`);
+    game.players.forEach(player => {
+        if (player.ws && player.ws.readyState === WebSocket.OPEN) {
+            try {
+                player.ws.send(JSON.stringify({ type: 'gameStateUpdate', payload: sanitizedGameState }));
+            } catch (error) {
+                console.error(`[WebSocket] Error sending state to player ${player.id} in game ${gameId}:`, error);
+            }
+        }
+    });
+};
+
+wss.on('connection', (ws, req) => {
+    const parameters = url.parse(req.url, true).query;
+    const gameId = parameters.gameId;
+    const connectingPlayerId = parameters.playerId; // Renamed to avoid conflict with 'player' variable
+
+    if (!gameId || !connectingPlayerId) {
+        console.log('[WebSocket] Connection rejected: Missing gameId or playerId.');
+        ws.terminate();
+        return;
+    }
+
+    if (!games[gameId]) {
+        console.log(`[WebSocket] Game ${gameId} not found for player ${connectingPlayerId}. Terminating.`);
+        ws.send(JSON.stringify({ type: 'error', message: 'Game not found. Ensure Game ID is correct.' }));
+        ws.terminate();
+        return;
+    }
+
+    const game = games[gameId];
+    let player = game.players.find(p => p.id === connectingPlayerId);
+
+    if (!player && game.players.length >= 2) {
+        console.log(`[WebSocket] Game ${gameId} is full. Player ${connectingPlayerId} cannot join. Terminating.`);
+        ws.send(JSON.stringify({ type: 'error', message: 'This game is already full.' }));
+        ws.terminate();
+        return;
+    }
+
+    if (!player) {
+        console.log(`[WebSocket] Player ${connectingPlayerId} not found in game ${gameId} (must join via HTTP first). Terminating.`);
+        ws.send(JSON.stringify({ type: 'error', message: 'Player not found in this game. Please join via HTTP POST first.' }));
+        ws.terminate();
+        return;
+    }
+
+    if (player.ws && player.ws.readyState === WebSocket.OPEN) {
+        console.log(`[WebSocket] Player ${connectingPlayerId} in game ${gameId} already has an active WebSocket connection. Terminating new connection.`);
+        ws.send(JSON.stringify({ type: 'error', message: 'Already connected. Closing this new connection.'}));
+        ws.terminate();
+        return;
+    }
+
+    player.ws = ws; // Assign the WebSocket connection to the player object
+    console.log(`[WebSocket] Client connected and associated: gameId=${gameId}, playerId=${connectingPlayerId}`);
+    ws.send(JSON.stringify({ type: 'connection_ack', message: `Connected to game ${gameId} as player ${connectingPlayerId}`}));
+
+    // If the other player was waiting due to a disconnection, update game state
+    if (game.state === 'opponent_disconnected' && game.players.length === 2) {
+        // Check if both players are now connected
+        const otherPlayer = game.players.find(p => p.id !== connectingPlayerId);
+        if (otherPlayer && otherPlayer.ws && otherPlayer.ws.readyState === WebSocket.OPEN) {
+            // Both players are connected, revert to previous active state (e.g. battle or selection)
+            // This needs more sophisticated state tracking to know what the "previous" state was.
+            // For now, let's assume if both selected pokemon, go to battle, else selection.
+            if (game.players.every(p => p.hasSelectedPokemon)) {
+                game.state = 'battle';
+                 if (!game.turn) { // If turn wasn't set or needs resetting
+                    game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
+                }
+            } else {
+                game.state = 'selecting_pokemon';
+            }
+            console.log(`[WebSocket] Player ${connectingPlayerId} reconnected. Game ${gameId} state changed to ${game.state}.`);
+        }
+    }
+    broadcastGameState(gameId); // Send current state to all, including newly connected/reconnected
+
+    ws.on('message', (message) => {
+        console.log(`[WebSocket] Msg from ${connectingPlayerId}@${gameId}: ${message}`);
+    });
+
+    ws.on('close', () => {
+        console.log(`[WebSocket] Client disconnected: gameId=${gameId}, playerId=${connectingPlayerId}`);
+        if (player) player.ws = null;
+
+        // Check if the game should be marked as opponent_disconnected
+        // Only if game was in an active state and not already finished
+        if (game && (game.state === 'battle' || game.state === 'selecting_pokemon' || game.state === 'waiting_for_other_player_selection')) {
+            // Check if the other player is still connected
+            const otherPlayer = game.players.find(p => p.id !== connectingPlayerId);
+            if (otherPlayer) { // If there is another player
+                game.state = 'opponent_disconnected';
+                game.turn = null; // No one's turn if someone is disconnected
+                console.log(`[Game ${gameId}] Player ${connectingPlayerId} disconnected. State changed to 'opponent_disconnected'.`);
+                broadcastGameState(gameId);
+            } else {
+                // If no other player, game might effectively end or reset (e.g. if only one player ever joined)
+                // For now, just log. If this was a 1-player game that got disconnected.
+                console.log(`[Game ${gameId}] Player ${connectingPlayerId} disconnected. No other players.`);
+            }
+        } else if (game && game.state === 'opponent_disconnected') {
+            // If one player disconnects, and then the other also disconnects while state is 'opponent_disconnected'
+            // The game is effectively abandoned. Could reset or mark as finished with no winner.
+            // For now, no further state change, just ensure ws is null.
+            console.log(`[Game ${gameId}] Player ${connectingPlayerId} disconnected while game was already in 'opponent_disconnected' state.`);
+        }
+    });
+
+    ws.on('error', (error) => {
+        console.error(`[WebSocket] Error for ${connectingPlayerId}@${gameId}:`, error);
+        if (player) player.ws = null; // Clean up on error too
+         if (game && (game.state === 'battle' || game.state === 'selecting_pokemon' || game.state === 'waiting_for_other_player_selection')) {
+            game.state = 'opponent_disconnected'; // Treat error same as close for game state
+            game.turn = null;
+            console.log(`[Game ${gameId}] Error on WS for ${connectingPlayerId}. State changed to 'opponent_disconnected'.`);
+            broadcastGameState(gameId);
+        }
+    });
 });
 
-// Route to join an existing game
+// --- Express Routes --- (No changes to routes needed for this specific subtask)
+
+app.post('/game', (req, res) => {
+    const gameId = `game_${Date.now()}`;
+    games[gameId] = { id: gameId, players: [], state: 'waiting_for_players', turn: null, winner: null };
+    console.log(`[Game ${gameId}] Created`);
+    res.status(201).json({ gameId, message: 'Game created. Join via /game/:id/join and connect WebSocket.' });
+});
+
 app.post('/game/:id/join', (req, res) => {
     const gameId = req.params.id;
     const { playerId } = req.body;
 
-    if (!games[gameId]) {
-        return res.status(404).json({ message: 'Game not found.' });
-    }
-
+    if (!games[gameId]) return res.status(404).json({ message: 'Game not found.' });
     const game = games[gameId];
+    let player = game.players.find(p => p.id === playerId);
 
-    if (game.players.length >= 2) {
+    if (player && player.ws && player.ws.readyState === WebSocket.OPEN) {
+        return res.status(400).json({ message: `Player ${playerId} already actively connected.` });
+    }
+    if (!player && game.players.length >= 2) {
         return res.status(400).json({ message: 'Game is already full.' });
     }
-    if (!playerId) {
-        return res.status(400).json({ message: 'Player ID is required to join the game.' });
-    }
-    if (game.players.find(p => p.id === playerId)) {
-        return res.status(400).json({ message: `Player ${playerId} already joined this game.` });
-    }
+    if (!playerId) return res.status(400).json({ message: 'Player ID required.' });
 
-    game.players.push({
-        id: playerId,
-        pokemon: null, // Pokemon (with full stats) will be stored here
-        hasSelectedPokemon: false
-    });
-    console.log(`[Game ${gameId}] Player ${playerId} joined`);
-
-    if (game.players.length === 2) {
-        game.state = 'selecting_pokemon';
-        console.log(`[Game ${gameId}] State changed to 'selecting_pokemon'`);
-        res.json({ gameId, message: `Player ${playerId} joined. Both players joined. Game is ready for Pokemon selection.` });
+    if (!player) {
+         player = { id: playerId, pokemon: null, hasSelectedPokemon: false, ws: null };
+         game.players.push(player);
+         console.log(`[Game ${gameId}] Player ${playerId} added to game`);
     } else {
-        res.json({ gameId, message: `Player ${playerId} joined. Waiting for another player.` });
+        console.log(`[Game ${gameId}] Player ${playerId} re-confirmed in game.`);
     }
+
+    let message = `Player ${playerId} in game ${gameId}.`;
+    if (game.players.length === 2 && game.state === 'waiting_for_players') {
+        game.state = 'selecting_pokemon';
+        message = `Both players joined. Game ready for Pokemon selection.`;
+        console.log(`[Game ${gameId}] State changed to 'selecting_pokemon'`);
+    } else if (game.players.length < 2) {
+        message = `Player ${playerId} joined. Waiting for opponent.`;
+    }
+
+    broadcastGameState(gameId);
+    res.json({ gameId, message, playerPId: player.id, currentGameState: game.state });
 });
 
-// Route to allow a player to select their Pokemon
 app.post('/game/:id/select-pokemon', (req, res) => {
     const gameId = req.params.id;
     const { playerId, pokemonName } = req.body;
 
-    if (!games[gameId]) {
-        return res.status(404).json({ message: 'Game not found.' });
-    }
+    if (!games[gameId]) return res.status(404).json({ message: 'Game not found.' });
     const game = games[gameId];
-
-    if (game.state !== 'selecting_pokemon') {
-        return res.status(400).json({ message: 'Game is not in Pokemon selection phase.' });
+    if (game.state !== 'selecting_pokemon' && game.state !== 'opponent_disconnected') {
+        // Allow selection if opponent disconnected and player needs to re-select or was in selection
+        if (!(game.state === 'opponent_disconnected' && game.players.find(p => p.id === playerId && !p.hasSelectedPokemon))) {
+            return res.status(400).json({ message: 'Not in selection phase.' });
+        }
     }
 
     const player = game.players.find(p => p.id === playerId);
-    if (!player) {
-        return res.status(404).json({ message: 'Player not found in this game.' });
+    if (!player) return res.status(404).json({ message: 'Player not found.' });
+    if (player.hasSelectedPokemon && game.state !== 'opponent_disconnected') {
+        return res.status(400).json({ message: 'Already selected.' });
     }
-    if (player.hasSelectedPokemon) {
-        return res.status(400).json({ message: `Player ${playerId} has already selected a Pokemon.` });
-    }
-    if (!pokemonName) {
-        return res.status(400).json({ message: 'Pokemon name is required.' });
-    }
+    if (!pokemonName) return res.status(400).json({ message: 'Pokemon name required.' });
 
     const pokemonDetails = getPokemonDetails(pokemonName);
-    if (!pokemonDetails) {
-        return res.status(404).json({ message: `Pokemon named ${pokemonName} not found.` });
-    }
+    if (!pokemonDetails) return res.status(404).json({ message: `Pokemon ${pokemonName} not found.` });
 
-    // Store the full Pokemon details and initialize currentHp
-    player.pokemon = {
-        ...pokemonDetails,
-        currentHp: pokemonDetails.stats.hp // Initialize current HP to max HP
-    };
+    player.pokemon = { ...pokemonDetails, currentHp: pokemonDetails.stats.hp };
     player.hasSelectedPokemon = true;
     console.log(`[Game ${gameId}] Player ${playerId} selected ${pokemonName}`);
 
+    let message = `Player ${playerId} selected ${pokemonName}.`;
     const allPlayersSelected = game.players.every(p => p.hasSelectedPokemon);
-    if (allPlayersSelected) {
+
+    if (game.state === 'opponent_disconnected') { // If one player selected while other was disconnected
+        const otherPlayer = game.players.find(p => p.id !== playerId);
+        if (otherPlayer && otherPlayer.ws && otherPlayer.ws.readyState === WebSocket.OPEN) { // If other player reconnected
+            if (allPlayersSelected) {
+                game.state = 'battle';
+                game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
+                message = `All Pokemon selected after reconnection. Battle begins! It's ${game.turn}'s turn.`;
+            } else {
+                game.state = 'selecting_pokemon'; // Back to selection if other player still needs to select
+                message = `Player ${playerId} selected. Waiting for other player to select after reconnection.`;
+            }
+        } else {
+             message += ` Waiting for opponent to reconnect.`; // Stay in opponent_disconnected or similar
+        }
+    } else if (allPlayersSelected) {
         game.state = 'battle';
-        // Randomly decide who goes first
         game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
-        console.log(`[Game ${gameId}] State changed to 'battle'. It's ${game.turn}'s turn.`);
-        res.json({
-            gameId,
-            message: `All Pokemon selected. Battle begins! It's ${game.turn}'s turn.`,
-            currentTurn: game.turn,
-            player1: {id: game.players[0].id, pokemon: game.players[0].pokemon},
-            player2: {id: game.players[1].id, pokemon: game.players[1].pokemon}
-        });
+        message = `All Pokemon selected. Battle begins! It's ${game.turn}'s turn.`;
+        console.log(`[Game ${gameId}] State changed to 'battle'. Turn: ${game.turn}`);
     } else {
-        res.json({ gameId, message: `Player ${playerId} selected ${pokemonName}. Waiting for other player.` });
+        message += ` Waiting for other player.`;
     }
+
+    broadcastGameState(gameId);
+    res.json({ gameId, message, currentTurn: game.turn, currentGameState: game.state });
 });
 
-// Route to allow a player to attack
 app.post('/game/:id/attack', (req, res) => {
     const gameId = req.params.id;
-    const { playerId, attackName } = req.body; // attackName can be used later for specific moves
+    const { playerId, attackName } = req.body;
 
-    if (!games[gameId]) {
-        return res.status(404).json({ message: 'Game not found.' });
-    }
+    if (!games[gameId]) return res.status(404).json({ message: 'Game not found.' });
     const game = games[gameId];
-
-    if (game.state !== 'battle') {
-        return res.status(400).json({ message: 'Game is not in battle phase.' });
-    }
-    if (game.turn !== playerId) {
-        return res.status(400).json({ message: `It's not player ${playerId}'s turn. It's ${game.turn}'s turn.` });
-    }
+    if (game.state !== 'battle') return res.status(400).json({ message: 'Not in battle phase.' });
+    if (game.turn !== playerId) return res.status(400).json({ message: `Not player ${playerId}'s turn.` });
 
     const attackerPlayer = game.players.find(p => p.id === playerId);
     const defenderPlayer = game.players.find(p => p.id !== playerId);
 
-    if (!attackerPlayer || !defenderPlayer || !attackerPlayer.pokemon || !defenderPlayer.pokemon) {
-        return res.status(500).json({ message: 'Error retrieving player or Pokemon data for battle.' });
+    if (!attackerPlayer?.pokemon || !defenderPlayer?.pokemon) {
+        return res.status(500).json({ message: 'Player or Pokemon data missing.' });
+    }
+    // Check if opponent is actually connected for an attack to be valid
+    if (!defenderPlayer.ws || defenderPlayer.ws.readyState !== WebSocket.OPEN) {
+        game.state = 'opponent_disconnected';
+        game.turn = null; // No one's turn
+        broadcastGameState(gameId);
+        return res.status(400).json({ message: 'Opponent is not connected. Cannot attack.', currentGameState: game.state });
     }
 
     const attackerPokemon = attackerPlayer.pokemon;
     const defenderPokemon = defenderPlayer.pokemon;
-
-    // Simple damage calculation: Attacker's Attack stat vs. Defender's Defense stat
-    // Add a random factor for variability, ensure minimum damage if attack > defense
-    let damage = Math.max(1, Math.floor(attackerPokemon.stats.attack * (Math.random() * 0.2 + 0.9)) - Math.floor(defenderPokemon.stats.defense * 0.5));
-
-    // Ensure damage is at least 1 if attacker's attack is greater than half of defender's defense, otherwise it could be 0 or negative.
-    // A more sophisticated formula would be better here.
-    if (attackerPokemon.stats.attack > defenderPokemon.stats.defense / 2 && damage <= 0) {
-        damage = 1 + Math.floor(Math.random() * 5); // Small random damage if calculation results in <=0
-    } else if (damage <=0) {
-        damage = 1; // Minimum 1 damage
-    }
-
+    let damage = Math.max(1, Math.floor(attackerPokemon.stats.attack * (Math.random()*0.2 + 0.9)) - Math.floor(defenderPokemon.stats.defense * 0.5));
+    if (attackerPokemon.stats.attack > defenderPokemon.stats.defense / 2 && damage <= 0) damage = 1 + Math.floor(Math.random()*5);
+    else if (damage <= 0) damage = 1;
 
     defenderPokemon.currentHp -= damage;
-    const usedAttack = attackName || "basic attack"; // Use provided attack name or default
+    const usedAttack = attackName || "basic attack";
+    console.log(`[Game ${gameId}] ${playerId} (${attackerPokemon.name}) attacked ${defenderPlayer.id} (${defenderPokemon.name}) for ${damage}. Defender HP: ${defenderPokemon.currentHp}`);
 
-    console.log(`[Game ${gameId}] Player ${playerId} (${attackerPokemon.name}) attacked ${defenderPlayer.id} (${defenderPokemon.name}) with ${usedAttack} for ${damage} damage. ${defenderPlayer.id} HP: ${defenderPokemon.currentHp}/${defenderPokemon.stats.hp}`);
-
+    let message;
     if (defenderPokemon.currentHp <= 0) {
-        defenderPokemon.currentHp = 0; // Ensure HP doesn't go negative
+        defenderPokemon.currentHp = 0;
         game.state = 'finished';
         game.winner = playerId;
+        message = `${playerId} (${attackerPokemon.name}) wins! ${defenderPlayer.id}'s ${defenderPokemon.name} fainted.`;
         console.log(`[Game ${gameId}] State changed to 'finished'. Winner: ${playerId}`);
-        res.json({
-            gameId,
-            message: `Player ${playerId} (${attackerPokemon.name}) wins! ${defenderPlayer.id}'s ${defenderPokemon.name} fainted.`,
-            winner: playerId,
-            attacker: { id: attackerPlayer.id, pokemon: attackerPokemon },
-            defender: { id: defenderPlayer.id, pokemon: defenderPokemon },
-        });
     } else {
-        // Switch turns
         game.turn = defenderPlayer.id;
-        res.json({
-            gameId,
-            message: `Player ${playerId} (${attackerPokemon.name}) attacked with ${usedAttack} for ${damage} damage. ${defenderPlayer.id}'s ${defenderPokemon.name} has ${defenderPokemon.currentHp}/${defenderPokemon.stats.hp} HP left. It's ${defenderPlayer.id}'s turn.`,
-            attacker: { id: attackerPlayer.id, pokemon: attackerPokemon },
-            defender: { id: defenderPlayer.id, pokemon: defenderPokemon },
-            nextTurn: defenderPlayer.id,
-        });
+        message = `${playerId} (${attackerPokemon.name}) attacked. ${defenderPlayer.id}'s ${defenderPokemon.name} has ${defenderPokemon.currentHp} HP. Turn: ${defenderPlayer.id}.`;
     }
+
+    broadcastGameState(gameId);
+    res.json({ gameId, message, currentGameState: game.state, currentTurn: game.turn, winner: game.winner });
 });
 
-// Route to get game state
 app.get('/game/:id', (req, res) => {
     const gameId = req.params.id;
-    if (!games[gameId]) {
+    const sanitizedGameState = getSanitizedGameState(gameId);
+    if (!sanitizedGameState) {
         return res.status(404).json({ message: 'Game not found.' });
     }
-    // Return a safe copy of the game state, perhaps omitting sensitive details if any in future
-    const game = games[gameId];
-    const playersSanitized = game.players.map(player => ({
-        id: player.id,
-        hasSelectedPokemon: player.hasSelectedPokemon,
-        pokemon: player.pokemon ? {
-            name: player.pokemon.name,
-            type: player.pokemon.type,
-            sprite: player.pokemon.sprite,
-            stats: player.pokemon.stats, // Send all stats
-            currentHp: player.pokemon.currentHp,
-            // Potentially omit full base stats if client doesn't need all of them once selected
-        } : null
-    }));
-
-    res.json({
-        id: game.id,
-        state: game.state,
-        turn: game.turn,
-        winner: game.winner,
-        players: playersSanitized,
-    });
+    res.json(sanitizedGameState);
 });
 
-app.listen(port, () => {
-    console.log(`Pokemon Battle Backend listening at http://localhost:${port}`);
+server.listen(port, () => {
+    console.log(`Pokemon Battle Backend with WebSocket server listening at http://localhost:${port}`);
 });
 
-module.exports = app;
+module.exports = { app, server };

--- a/pokemon-battle-backend/package.json
+++ b/pokemon-battle-backend/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
-    "express": "^4.17.1"
+    "express": "^4.17.1",
+    "ws": "^8.17.0"
   },
   "author": "",
   "license": "ISC"

--- a/pokemon-battle/src/App.jsx
+++ b/pokemon-battle/src/App.jsx
@@ -2,264 +2,312 @@ import { useState, useEffect } from 'react';
 import axios from 'axios';
 import './App.css';
 import PokemonSelection from './components/PokemonSelection';
-import BattleUI from './components/BattleUI'; // Import BattleUI
+import BattleUI from './components/BattleUI';
 
-// Configuration for the backend API URL
 const API_BASE_URL = 'http://localhost:3000';
+const WS_BASE_URL = 'ws://localhost:3000';
 
 function App() {
-  const [gameState, setGameState] = useState('initial'); // initial, creating_game, waiting_for_opponent, selecting_pokemon, battle, finished
+  const [gameState, setGameState] = useState('initial');
   const [gameId, setGameId] = useState(null);
   const [playerId, setPlayerId] = useState(null);
   const [message, setMessage] = useState('');
   const [error, setError] = useState('');
   const [isLoading, setIsLoading] = useState(false);
-  const [gameData, setGameData] = useState(null); // To store the full game state from backend
+  const [isWsLoading, setIsWsLoading] = useState(false);
+  const [gameData, setGameData] = useState(null);
+  const [socket, setSocket] = useState(null);
 
-  // Function to create a new game
+  const updateFullGameState = (newGameData, sourceMessage = "") => {
+    setGameData(newGameData);
+    setGameState(newGameData.state);
+
+    let statusMessage = sourceMessage || `Game state: ${newGameData.state}.`;
+    if (newGameData.state === 'battle') {
+      statusMessage = `Battle ongoing! Turn: ${newGameData.turn}.`;
+    } else if (newGameData.state === 'selecting_pokemon') {
+      statusMessage = "Select your Pokemon.";
+    } else if (newGameData.state === 'waiting_for_other_player_selection') {
+        statusMessage = "Waiting for opponent to select Pokemon.";
+    } else if (newGameData.state === 'waiting_for_opponent') {
+        statusMessage = `Game ID: ${newGameData.id}. Waiting for opponent to join and connect.`;
+    } else if (newGameData.state === 'finished') {
+      statusMessage = `Game Over! Winner: ${newGameData.winner}!`;
+      if (newGameData.winner === playerId) {
+        statusMessage = "Congratulations, you won!";
+      } else {
+        statusMessage = "You lost. Better luck next time!";
+      }
+    } else if (newGameData.state === 'opponent_disconnected') {
+        statusMessage = "Opponent disconnected. Waiting for them to rejoin or game may be reset.";
+    }
+
+    setMessage(statusMessage);
+    setIsLoading(false);
+    setIsWsLoading(false);
+    console.log(`[StateUpdate] Source: ${sourceMessage || 'WS'}`, newGameData);
+  };
+
+  useEffect(() => {
+    if (!socket) return;
+
+    socket.onopen = () => {
+      console.log(`[WebSocket] Connected: game ${gameId}, player ${playerId}`);
+      setMessage(prev => `WebSocket connected. ${prev}`);
+      setIsWsLoading(false);
+    };
+
+    socket.onmessage = (event) => {
+      console.log('[WebSocket] Raw message:', event.data);
+      try {
+        const data = JSON.parse(event.data);
+        console.log('[WebSocket] Parsed message:', data);
+
+        if (data.type === 'gameStateUpdate') {
+          updateFullGameState(data.payload, "WebSocket Game Update");
+        } else if (data.type === 'connection_ack') {
+          setMessage(prev => `Server: ${data.message}. ${prev}`);
+        } else if (data.type === 'error') {
+          setError(`Server error: ${data.message}`);
+        } else {
+          console.log('[WebSocket] Unhandled message type:', data.type);
+        }
+      } catch (e) {
+        console.error('[WebSocket] Parse/handle error:', e, event.data);
+        setError("Malformed data from server.");
+      }
+    };
+
+    socket.onclose = (event) => {
+      console.log(`[WebSocket] Disconnected. Code: ${event.code}, Reason: ${event.reason || 'N/A'}`);
+      // Only set message if game was active, not on initial cleanup/reset
+      if (gameId && gameState !== 'initial' && gameState !== 'finished') {
+          setMessage(prev => "WebSocket disconnected. Game may be interrupted.");
+          // Consider if game state should change to 'opponent_disconnected' or similar
+          // This might be better handled by a specific server message if one player disconnects mid-game
+      }
+      setIsWsLoading(false);
+      // setSocket(null); // Let main cleanup or connectWebSocket handle this
+    };
+
+    socket.onerror = (err) => {
+      console.error('[WebSocket] Error:', err.message || 'Unknown WS error');
+      setError("WebSocket connection error. See console.");
+      setIsWsLoading(false);
+    };
+  }, [socket, gameId, playerId]); // Dependencies for context within handlers
+
+  const connectWebSocket = (currentGId, currentPId) => {
+    if (!currentGId || !currentPId) {
+      console.log('[WebSocket] Connect: gameId or playerId missing.'); return;
+    }
+    if (socket && socket.readyState === WebSocket.OPEN && socket.url.includes(`gameId=${currentGId}&playerId=${currentPId}`)) {
+      console.log('[WebSocket] Already connected with same parameters.'); return;
+    }
+    if (socket) socket.close();
+
+    setIsWsLoading(true);
+    setMessage(prev => `Connecting to game server... ${prev}`);
+    const socketUrl = `${WS_BASE_URL}?gameId=${currentGId}&playerId=${currentPId}`;
+    console.log(`[WebSocket] Attempting to connect to ${socketUrl}`);
+    setSocket(new WebSocket(socketUrl));
+  };
+
+  useEffect(() => { // Main cleanup effect
+    return () => { if (socket) socket.close(); };
+  }, [socket]);
+
+
   const createNewGame = async () => {
-    setIsLoading(true);
-    setError('');
-    setMessage('Creating game...');
+    setIsLoading(true); setError(''); setMessage('Creating new game...');
+    resetGame(false); // Soft reset, keep socket for now, joinGame will handle it
+
     try {
       const response = await axios.post(`${API_BASE_URL}/game`);
       const newGameId = response.data.gameId;
+      const newPlayerId = 'player1';
+      // Set Ids immediately for joinGame to use
       setGameId(newGameId);
-      const newPlayerId = 'player1'; // Creator is player1
       setPlayerId(newPlayerId);
-      // setMessage(`Game created: ${newGameId}. Joining as ${newPlayerId}...`);
-      console.log("Game created:", response.data);
-      await joinGame(newGameId, newPlayerId, true); // Auto-join creator
+      console.log("Game created:", newGameId, "Player ID:", newPlayerId);
+      await joinGame(newGameId, newPlayerId, true);
     } catch (err) {
       console.error("Error creating game:", err);
-      setError(err.response?.data?.message || 'Failed to create game. Is the backend server running?');
-      setMessage('');
-      setGameState('initial');
-    } finally {
-      // setIsLoading(false); // setIsLoading is handled by joinGame or fetchGameState
+      setError(err.response?.data?.message || 'Failed to create game.');
+      resetGame();
     }
   };
 
-  // Function to join an existing game
   const joinGame = async (gameIdToJoin, newPlayerId, isCreator = false) => {
     if (!gameIdToJoin) {
-      setError("Please enter a Game ID to join.");
-      return;
+      setError("Please enter a Game ID."); setIsLoading(false); return;
     }
-    setIsLoading(true);
-    setError('');
+    setIsLoading(true); setError('');
+    if (!isCreator) { // If not creator, this is a fresh join, reset prior game/socket
+        resetGame(false); // Soft reset, keep socket for now
+        setGameId(gameIdToJoin); // Set IDs for this new game attempt
+        setPlayerId(newPlayerId);
+    }
     setMessage(`Joining game ${gameIdToJoin} as ${newPlayerId}...`);
     try {
       const response = await axios.post(`${API_BASE_URL}/game/${gameIdToJoin}/join`, { playerId: newPlayerId });
-      setGameId(gameIdToJoin); // Set gameId from the input/creation
-      setPlayerId(newPlayerId); // Set player ID
-      // Message will be updated by fetchGameState
-      console.log("Game joined response:", response.data);
-      await fetchGameState(gameIdToJoin, response.data.message); // Fetch state to confirm and get game data
+      // gameId and playerId are already set
+      console.log("Game joined HTTP response:", response.data);
+      await fetchGameState(gameIdToJoin, `Joined game ${gameIdToJoin}. ${response.data.message}`);
     } catch (err) {
       console.error(`Error joining game ${gameIdToJoin}:`, err);
-      setError(err.response?.data?.message || `Failed to join game. Ensure Game ID is correct and backend is running.`);
-      if (isCreator) {
-        setGameState('initial');
-        setGameId(null);
-        setPlayerId(null);
-      }
-      setMessage('');
-      setIsLoading(false);
+      setError(err.response?.data?.message || `Failed to join game.`);
+      resetGame();
     }
   };
 
-  // Function to fetch the current game state
-  const fetchGameState = async (currentGamId, initialMessage = '') => {
-    if (!currentGamId) {
-        setError("No game ID to fetch state for.");
-        setIsLoading(false);
-        return;
+  const fetchGameState = async (currentGID, initialMessage = '') => {
+    if (!currentGID) {
+      setError("No game ID to fetch state for."); setIsLoading(false); return;
     }
-    setIsLoading(true);
-    setError(''); // Clear previous errors
-    // setMessage(prev => initialMessage || prev || "Fetching game state...");
-    let currentMsg = initialMessage || "Fetching game state...";
-
+    setIsLoading(true); // For HTTP fetch
     try {
-      const response = await axios.get(`${API_BASE_URL}/game/${currentGamId}`);
+      const response = await axios.get(`${API_BASE_URL}/game/${currentGID}`);
       const fetchedGameData = response.data;
-      setGameData(fetchedGameData);
-      setGameState(fetchedGameData.state);
-      setGameId(currentGamId); // Ensure gameId is set from fetched data if not already
+      updateFullGameState(fetchedGameData, initialMessage || "Fetched game state via HTTP.");
 
-      currentMsg += ` Current state: ${fetchedGameData.state}.`;
-      if (fetchedGameData.state === 'battle') {
-        currentMsg += ` It's ${fetchedGameData.turn}'s turn.`;
-      } else if (fetchedGameData.state === 'selecting_pokemon') {
-         currentMsg += ` Waiting for players to select Pokemon.`;
-      } else if (fetchedGameData.state === 'waiting_for_opponent') {
-        currentMsg += ` Game ID: ${currentGamId}. Waiting for opponent...`;
-      } else if (fetchedGameData.state === 'finished') {
-        currentMsg += ` Winner: ${fetchedGameData.winner}!`;
+      if (currentGID && playerId && (fetchedGameData.state !== 'initial' && fetchedGameData.state !== 'finished')) {
+        connectWebSocket(currentGID, playerId);
       }
-      setMessage(currentMsg);
-      console.log("Game state fetched:", fetchedGameData);
     } catch (err) {
       console.error("Error fetching game state:", err);
       setError(err.response?.data?.message || "Could not fetch game state.");
-      // Don't reset gameId/playerId here unless game not found
-      if (err.response?.status === 404) {
-        setMessage('');
-        setGameId(null); // Reset gameId if not found
-      }
-    } finally {
-      setIsLoading(false);
+      if (err.response?.status === 404) resetGame();
+      else setIsLoading(false);
     }
   };
 
-  // Handler for when Pokemon selection is confirmed
   const handlePokemonSelected = async (selectedPokemon) => {
     if (!gameId || !playerId || !selectedPokemon) {
-      setError('Game ID, Player ID, or Pokemon not set. Cannot confirm selection.');
-      return;
+      setError('Game/Player ID or Pokemon not set.'); return;
     }
-    setIsLoading(true);
-    setError('');
-    setMessage(`Confirming selection of ${selectedPokemon.name}...`);
+    setIsLoading(true); setError(''); setMessage(`Sending selection: ${selectedPokemon.name}...`);
     try {
-      const response = await axios.post(`${API_BASE_URL}/game/${gameId}/select-pokemon`, {
-        playerId: playerId,
-        pokemonName: selectedPokemon.name
-      });
-      // setMessage(response.data.message); // Message will be updated by fetchGameState
-      console.log("Pokemon selection response:", response.data);
-      await fetchGameState(gameId, response.data.message); // Refresh game state
+      await axios.post(`${API_BASE_URL}/game/${gameId}/select-pokemon`,
+        { playerId: playerId, pokemonName: selectedPokemon.name }
+      );
+      console.log(`Selection of ${selectedPokemon.name} sent. Waiting for WS update.`);
+      // setIsLoading(false) will be called by updateFullGameState from WS broadcast
     } catch (err) {
       console.error("Error confirming Pokemon selection:", err);
-      setError(err.response?.data?.message || 'Failed to confirm Pokemon selection.');
-      setMessage('');
+      setError(err.response?.data?.message || 'Failed to confirm selection.');
       setIsLoading(false);
     }
   };
 
-  // Handler for attack button
   const handleAttack = async () => {
-    if (!gameId || !playerId) {
-      setError('Game ID or Player ID not set. Cannot attack.');
-      return;
+    if (!gameId || !playerId || (gameData && gameData.turn !== playerId)) {
+      setError('Not your turn or game not ready.'); return;
     }
-    setIsLoading(true);
+    // No setIsLoading(true) here; rely on WS for feedback if possible to avoid UI flicker.
+    // If WS is slow, this might feel unresponsive. Consider a very short isLoading timeout.
     setError('');
-    setMessage('Attacking...');
     try {
-      const response = await axios.post(`${API_BASE_URL}/game/${gameId}/attack`, {
-        playerId: playerId,
-        // attackName: "basic_attack" // Optional: can be expanded later
-      });
-      // setMessage(response.data.message); // Message will be updated by fetchGameState
-      console.log("Attack response:", response.data);
-      await fetchGameState(gameId, response.data.message); // Refresh game state
+      await axios.post(`${API_BASE_URL}/game/${gameId}/attack`, { playerId: playerId });
+      console.log('Attack action sent. Waiting for WS update.');
     } catch (err) {
       console.error("Error during attack:", err);
       setError(err.response?.data?.message || 'Failed to perform attack.');
-      // setMessage(''); // Keep last successful message or error message
-      setIsLoading(false); // Explicitly set loading to false on error
-      // It's possible fetchGameState above might not be called if error is here.
-      // So, ensure UI can recover or show the error.
-      // We might want to call fetchGameState even in catch if game still exists
-      if (gameId) {
-          await fetchGameState(gameId, err.response?.data?.message || 'Failed to perform attack.');
-      }
+      // Fetch state to resync if HTTP attack call itself fails
+      await fetchGameState(gameId, "Error during attack, attempting to resync state.");
     }
   };
 
   const [joinGameIdInput, setJoinGameIdInput] = useState('');
 
-  const resetGame = () => {
+  const resetGame = (fullResetSocket = true) => {
+    if (fullResetSocket && socket) {
+      socket.close();
+      setSocket(null);
+    } else if (!fullResetSocket && socket && socket.readyState !== WebSocket.OPEN && socket.readyState !== WebSocket.CONNECTING) {
+      // If not a full reset, but socket is in a bad state, nullify it to allow reconnect
+      setSocket(null);
+    }
     setGameState('initial');
     setGameId(null);
     setPlayerId(null);
     setGameData(null);
-    setMessage('');
-    setError('');
+    setMessage(''); // Clear messages on reset
+    setError('');   // Clear errors on reset
     setJoinGameIdInput('');
-  }
+    setIsLoading(false);
+    setIsWsLoading(false);
+  };
+
+  // Button to manually attempt WebSocket connection if it failed or to refresh state
+  const manualConnectButton = (
+    <button onClick={() => fetchGameState(gameId, "Attempting to connect WebSocket and refresh state...")} disabled={isWsLoading || isLoading}>
+      {isWsLoading ? 'Connecting WS...' : 'Connect WS / Refresh State'}
+    </button>
+  );
 
   return (
     <div className="App">
       <header className="App-header">
         <h1>Pokemon Battle Game</h1>
-        {gameId && <p className="game-info-header">Game ID: {gameId} | Your Player ID: {playerId}</p>}
+        {gameId && <p className="game-info-header">Game: {gameId} | Player: {playerId} | Socket: {socket ? socket.readyState : 'N/A'} {isWsLoading ? '(Connecting...)' : ''}</p>}
       </header>
       <main>
-        {isLoading && <p className="loading-message">Loading...</p>}
+        {isLoading && <p className="loading-message">Loading Game Data...</p>}
+        {isWsLoading && !isLoading && <p className="loading-message">Connecting to Game Server...</p>}
         {error && <p className="error-message">Error: {error}</p>}
-        {message && !error && <p className="message">{message}</p>} {/* Show message if no error or if error is shown separately */}
-
+        {message && <p className="message">{message}</p>}
 
         {gameState === 'initial' && (
           <div className="initial-actions">
-            <button onClick={createNewGame} disabled={isLoading}>Create New Game</button>
+            <button onClick={createNewGame} disabled={isLoading || isWsLoading}>Create New Game</button>
             <hr style={{margin: '20px 0'}}/>
             <div>
-              <input
-                type="text"
-                placeholder="Enter Game ID to Join"
-                value={joinGameIdInput}
-                onChange={(e) => setJoinGameIdInput(e.target.value)}
-                disabled={isLoading}
-              />
-              <button onClick={() => joinGame(joinGameIdInput, 'player2')} disabled={isLoading || !joinGameIdInput}>Join Game</button>
+              <input type="text" placeholder="Enter Game ID to Join" value={joinGameIdInput} onChange={(e) => setJoinGameIdInput(e.target.value)} disabled={isLoading || isWsLoading}/>
+              <button onClick={() => joinGame(joinGameIdInput, 'player2')} disabled={isLoading || isWsLoading || !joinGameIdInput}>Join Game</button>
             </div>
           </div>
         )}
 
         {(gameState === 'waiting_for_opponent' && gameData) && (
           <div>
-            <p>Share Game ID: <strong>{gameData.id}</strong> with your opponent.</p>
-            <p>Waiting for opponent to join...</p>
-            <button onClick={() => fetchGameState(gameData.id)} disabled={isLoading}>Refresh Status</button>
+            {/* Message state handles this now */}
+            {(!socket || socket.readyState !== WebSocket.OPEN) && manualConnectButton}
           </div>
         )}
 
         {gameState === 'selecting_pokemon' && gameId && playerId && (
-          <PokemonSelection
-            onSelectionConfirmed={handlePokemonSelected}
-            playerId={playerId}
-            gameId={gameId}
-            // isLoading={isLoading} // Pass loading if PokemonSelection needs it
-          />
+          <PokemonSelection onSelectionConfirmed={handlePokemonSelected} playerId={playerId} gameId={gameId} />
         )}
 
-        {gameState === 'waiting_for_other_player_selection' && gameData && (
+        {(gameState === 'waiting_for_other_player_selection' || gameState === 'opponent_disconnected') && gameData && (
             <div>
-                <p>Waiting for the other player to select their Pokemon...</p>
+                 {/* Message state handles this now */}
                 {gameData?.players?.find(p=>p.id === playerId)?.pokemon &&
                   <p>Your Pokemon: {gameData.players.find(p=>p.id === playerId).pokemon.name}</p>
                 }
-                <button onClick={() => fetchGameState(gameId)} disabled={isLoading}>Refresh Status</button>
+                 {gameState === 'opponent_disconnected' && (!socket || socket.readyState !== WebSocket.OPEN) && manualConnectButton}
             </div>
         )}
 
         {(gameState === 'battle' || gameState === 'finished') && gameData && playerId && (
-          <BattleUI
-            gameData={gameData}
-            playerId={playerId}
-            onAttack={handleAttack}
-            isLoading={isLoading}
-          />
+          <BattleUI gameData={gameData} playerId={playerId} onAttack={handleAttack} isLoading={isLoading /* Pass isLoading for attack button feedback */} />
         )}
 
-        {/* Universal refresh button if gameId exists and not initial state */}
-        {gameState !== 'initial' && gameId && (
-             <button onClick={() => fetchGameState(gameId)} disabled={isLoading} style={{marginTop: '20px'}}>
-                Refresh Game State
-            </button>
+        {/* Removed general refresh button. Reset button is kept. */}
+        {/* A manual WS reconnect button can be useful if connection drops often */}
+        {gameState !== 'initial' && gameId && (!socket || (socket.readyState !== WebSocket.OPEN && socket.readyState !== WebSocket.CONNECTING)) && gameState !== 'finished' && (
+             <div style={{marginTop: '20px'}}>
+                <p>WebSocket not connected.</p>
+                {manualConnectButton}
+            </div>
         )}
 
-        {/* Button to go back to home/reset */}
         {gameState !== 'initial' && (
-            <button onClick={resetGame} style={{marginTop: '10px', backgroundColor: '#7f8c8d'}}>
-                Reset and Go Home
+            <button onClick={() => resetGame(true)} style={{marginTop: '10px', backgroundColor: '#7f8c8d'}}>
+                Reset Game & Disconnect
             </button>
         )}
-
       </main>
     </div>
   );


### PR DESCRIPTION
This commit introduces WebSocket functionality for real-time, two-way communication between clients and the server, enabling automatic game state synchronization without manual refreshing.

Backend (`pokemon-battle-backend`):
- Added `ws` (WebSocket) library.
- Integrated WebSocket server with the existing Express HTTP server.
- Handles WebSocket connections, associating them with `gameId` and `playerId`.
- Broadcasts sanitized game state updates to all relevant clients in a game after key actions (join, Pokemon selection, attack, disconnect).
- Manages player disconnections by updating game state and notifying the other player.
- Includes logic to attempt game state recovery if a disconnected player rejoins.

Frontend (`pokemon-battle`):
- Establishes a WebSocket connection when a game is active.
- Manages WebSocket lifecycle (open, message, close, error).
- Handles incoming `gameStateUpdate` messages from the server, updating the local React state to reflect changes in real-time.
- Refined UI/UX:
    - Removed most manual refresh buttons.
    - Improved loading and status messages.
    - Displays messages for opponent disconnections and provides a manual reconnect option if your WebSocket is also down.

This provides a more dynamic and interactive experience for players. Manual two-player testing is recommended to ensure smooth real-world operation.