### PR TITLE
feat: Implement 6-Pokemon battles with fainting and switching

### DIFF
--- a/pokemon-battle-backend/index.js
+++ b/pokemon-battle-backend/index.js
@@ -8,6 +8,7 @@ const url = require('url');
 
 const app = express();
 const port = process.env.PORT || 3000;
+const MAX_TEAM_SIZE = 6;
 
 const games = {};
 
@@ -17,38 +18,27 @@ app.use(bodyParser.json());
 const server = http.createServer(app);
 const wss = new WebSocket.Server({ server });
 
-// Helper function to sanitize game state for broadcasting (remove ws objects)
 const getSanitizedGameState = (gameId) => {
     if (!games[gameId]) return null;
     const game = games[gameId];
-    // Create a deep copy to avoid mutating the original 'ws' property on players
     const gameCopy = JSON.parse(JSON.stringify(game));
-    gameCopy.players.forEach(p => delete p.ws); // Remove ws from the copy
+    if (gameCopy.players) {
+        gameCopy.players.forEach(p => { delete p.ws; });
+    }
     return gameCopy;
 };
 
-// Helper function to broadcast game state to all connected clients in a game
 const broadcastGameState = (gameId) => {
     const game = games[gameId];
-    if (!game) {
-        console.log(`[WebSocket] Broadcast: Game ${gameId} not found, cannot broadcast.`);
-        return;
-    }
-
-    const sanitizedGameState = getSanitizedGameState(gameId); // Use the modified sanitizer
-    if (!sanitizedGameState) {
-        console.log(`[WebSocket] Broadcast: Sanitized game state for ${gameId} is null, cannot broadcast.`);
-        return;
-    }
-
-    console.log(`[WebSocket] Broadcasting game state for game ${gameId} to players.`);
+    if (!game) { console.log(`[WS] Broadcast: Game ${gameId} not found.`); return; }
+    const sanitizedGameState = getSanitizedGameState(gameId);
+    if (!sanitizedGameState) { console.log(`[WS] Broadcast: Sanitized GState for ${gameId} is null.`); return; }
+    console.log(`[WS] Broadcasting GState for ${gameId} to ${game.players.length} players.`);
     game.players.forEach(player => {
         if (player.ws && player.ws.readyState === WebSocket.OPEN) {
             try {
                 player.ws.send(JSON.stringify({ type: 'gameStateUpdate', payload: sanitizedGameState }));
-            } catch (error) {
-                console.error(`[WebSocket] Error sending state to player ${player.id} in game ${gameId}:`, error);
-            }
+            } catch (error) { console.error(`[WS] Error sending state to ${player.id} in ${gameId}:`, error); }
         }
     });
 };
@@ -56,115 +46,118 @@ const broadcastGameState = (gameId) => {
 wss.on('connection', (ws, req) => {
     const parameters = url.parse(req.url, true).query;
     const gameId = parameters.gameId;
-    const connectingPlayerId = parameters.playerId; // Renamed to avoid conflict with 'player' variable
+    const connectingPlayerId = parameters.playerId;
 
-    if (!gameId || !connectingPlayerId) {
-        console.log('[WebSocket] Connection rejected: Missing gameId or playerId.');
-        ws.terminate();
-        return;
-    }
-
-    if (!games[gameId]) {
-        console.log(`[WebSocket] Game ${gameId} not found for player ${connectingPlayerId}. Terminating.`);
-        ws.send(JSON.stringify({ type: 'error', message: 'Game not found. Ensure Game ID is correct.' }));
-        ws.terminate();
-        return;
-    }
+    if (!gameId || !connectingPlayerId) { ws.terminate(); return; }
+    if (!games[gameId]) { ws.send(JSON.stringify({ type: 'error', message: 'Game not found.' })); ws.terminate(); return; }
 
     const game = games[gameId];
     let player = game.players.find(p => p.id === connectingPlayerId);
 
-    if (!player && game.players.length >= 2) {
-        console.log(`[WebSocket] Game ${gameId} is full. Player ${connectingPlayerId} cannot join. Terminating.`);
-        ws.send(JSON.stringify({ type: 'error', message: 'This game is already full.' }));
-        ws.terminate();
-        return;
-    }
+    if (!player && game.players.length >= 2) { ws.send(JSON.stringify({ type: 'error', message: 'Game is full.' })); ws.terminate(); return; }
+    if (!player) { ws.send(JSON.stringify({ type: 'error', message: 'Player not found. Join via HTTP first.' })); ws.terminate(); return; }
+    if (player.ws && player.ws.readyState === WebSocket.OPEN) { ws.send(JSON.stringify({ type: 'error', message: 'Already connected.' })); ws.terminate(); return; }
 
-    if (!player) {
-        console.log(`[WebSocket] Player ${connectingPlayerId} not found in game ${gameId} (must join via HTTP first). Terminating.`);
-        ws.send(JSON.stringify({ type: 'error', message: 'Player not found in this game. Please join via HTTP POST first.' }));
-        ws.terminate();
-        return;
-    }
+    player.ws = ws;
+    console.log(`[WS] Client connected: gameId=${gameId}, playerId=${connectingPlayerId}`);
+    ws.send(JSON.stringify({ type: 'connection_ack', message: `Connected to game ${gameId} as ${connectingPlayerId}`}));
 
-    if (player.ws && player.ws.readyState === WebSocket.OPEN) {
-        console.log(`[WebSocket] Player ${connectingPlayerId} in game ${gameId} already has an active WebSocket connection. Terminating new connection.`);
-        ws.send(JSON.stringify({ type: 'error', message: 'Already connected. Closing this new connection.'}));
-        ws.terminate();
-        return;
-    }
-
-    player.ws = ws; // Assign the WebSocket connection to the player object
-    console.log(`[WebSocket] Client connected and associated: gameId=${gameId}, playerId=${connectingPlayerId}`);
-    ws.send(JSON.stringify({ type: 'connection_ack', message: `Connected to game ${gameId} as player ${connectingPlayerId}`}));
-
-    // If the other player was waiting due to a disconnection, update game state
     if (game.state === 'opponent_disconnected' && game.players.length === 2) {
-        // Check if both players are now connected
         const otherPlayer = game.players.find(p => p.id !== connectingPlayerId);
         if (otherPlayer && otherPlayer.ws && otherPlayer.ws.readyState === WebSocket.OPEN) {
-            // Both players are connected, revert to previous active state (e.g. battle or selection)
-            // This needs more sophisticated state tracking to know what the "previous" state was.
-            // For now, let's assume if both selected pokemon, go to battle, else selection.
-            if (game.players.every(p => p.hasSelectedPokemon)) {
+            if (game.players.every(p => p.hasSelectedParty)) {
                 game.state = 'battle';
-                 if (!game.turn) { // If turn wasn't set or needs resetting
-                    game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
-                }
+                 if (!game.turn) game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
             } else {
                 game.state = 'selecting_pokemon';
             }
-            console.log(`[WebSocket] Player ${connectingPlayerId} reconnected. Game ${gameId} state changed to ${game.state}.`);
+            console.log(`[WS] Player ${connectingPlayerId} reconnected. Game ${gameId} state -> ${game.state}.`);
         }
     }
-    broadcastGameState(gameId); // Send current state to all, including newly connected/reconnected
+    broadcastGameState(gameId);
 
-    ws.on('message', (message) => {
-        console.log(`[WebSocket] Msg from ${connectingPlayerId}@${gameId}: ${message}`);
+    ws.on('message', (messageString) => {
+        console.log(`[WS] Msg from ${connectingPlayerId}@${gameId}: ${messageString}`);
+        let parsedMessage;
+        try {
+            parsedMessage = JSON.parse(messageString);
+        } catch (error) {
+            console.error(`[WS] Failed to parse message from ${connectingPlayerId}: ${messageString}`);
+            ws.send(JSON.stringify({ type: 'error', message: 'Invalid message format.' }));
+            return;
+        }
+
+        if (parsedMessage.type === 'switchPokemon') {
+            const { newActivePokemonIndex } = parsedMessage.payload;
+
+            // Validation
+            if (game.state !== 'waiting_for_switch') {
+                ws.send(JSON.stringify({ type: 'error', message: 'Not the time to switch Pokemon.' }));
+                return;
+            }
+            if (game.turn !== connectingPlayerId) {
+                ws.send(JSON.stringify({ type: 'error', message: 'Not your turn to switch.' }));
+                return;
+            }
+            if (newActivePokemonIndex == null || player.party[newActivePokemonIndex] == null) {
+                ws.send(JSON.stringify({ type: 'error', message: 'Invalid Pokemon index for switch.' }));
+                return;
+            }
+            if (player.party[newActivePokemonIndex].status === 'fainted') {
+                ws.send(JSON.stringify({ type: 'error', message: 'Cannot switch to a fainted Pokemon.' }));
+                return;
+            }
+            if (player.activePokemonIndex === newActivePokemonIndex) {
+                 ws.send(JSON.stringify({ type: 'error', message: 'This Pokemon is already active.' }));
+                return;
+            }
+
+            // Perform Switch
+            player.activePokemonIndex = newActivePokemonIndex;
+            game.state = 'battle'; // Return to battle state
+
+            // Turn goes to the opponent
+            const opponentPlayer = game.players.find(p => p.id !== connectingPlayerId);
+            if (opponentPlayer) {
+                game.turn = opponentPlayer.id;
+            } else {
+                // Should not happen in a 2-player game, but handle defensively
+                console.error(`[Game ${gameId}] Opponent not found for turn switch!`);
+                game.turn = null; // Or handle as an error state
+            }
+
+            console.log(`[Game ${gameId}] Player ${connectingPlayerId} switched to Pokemon at index ${newActivePokemonIndex}. Game state -> 'battle'. Turn -> ${game.turn}`);
+            broadcastGameState(gameId);
+        }
+        // Future message types can be handled here
     });
 
     ws.on('close', () => {
-        console.log(`[WebSocket] Client disconnected: gameId=${gameId}, playerId=${connectingPlayerId}`);
+        console.log(`[WS] Client disconnected: gameId=${gameId}, playerId=${connectingPlayerId}`);
         if (player) player.ws = null;
-
-        // Check if the game should be marked as opponent_disconnected
-        // Only if game was in an active state and not already finished
-        if (game && (game.state === 'battle' || game.state === 'selecting_pokemon' || game.state === 'waiting_for_other_player_selection')) {
-            // Check if the other player is still connected
+        if (game && ['battle', 'selecting_pokemon', 'waiting_for_other_player_selection', 'waiting_for_switch'].includes(game.state)) {
             const otherPlayer = game.players.find(p => p.id !== connectingPlayerId);
-            if (otherPlayer) { // If there is another player
-                game.state = 'opponent_disconnected';
-                game.turn = null; // No one's turn if someone is disconnected
-                console.log(`[Game ${gameId}] Player ${connectingPlayerId} disconnected. State changed to 'opponent_disconnected'.`);
+            if (otherPlayer) {
+                game.state = 'opponent_disconnected'; game.turn = null;
+                console.log(`[Game ${gameId}] ${connectingPlayerId} disconnected. State -> 'opponent_disconnected'.`);
                 broadcastGameState(gameId);
-            } else {
-                // If no other player, game might effectively end or reset (e.g. if only one player ever joined)
-                // For now, just log. If this was a 1-player game that got disconnected.
-                console.log(`[Game ${gameId}] Player ${connectingPlayerId} disconnected. No other players.`);
-            }
+            } else { console.log(`[Game ${gameId}] ${connectingPlayerId} disconnected. No other players.`); }
         } else if (game && game.state === 'opponent_disconnected') {
-            // If one player disconnects, and then the other also disconnects while state is 'opponent_disconnected'
-            // The game is effectively abandoned. Could reset or mark as finished with no winner.
-            // For now, no further state change, just ensure ws is null.
-            console.log(`[Game ${gameId}] Player ${connectingPlayerId} disconnected while game was already in 'opponent_disconnected' state.`);
+            console.log(`[Game ${gameId}] ${connectingPlayerId} disconnected while already 'opponent_disconnected'.`);
         }
     });
-
     ws.on('error', (error) => {
-        console.error(`[WebSocket] Error for ${connectingPlayerId}@${gameId}:`, error);
-        if (player) player.ws = null; // Clean up on error too
-         if (game && (game.state === 'battle' || game.state === 'selecting_pokemon' || game.state === 'waiting_for_other_player_selection')) {
-            game.state = 'opponent_disconnected'; // Treat error same as close for game state
-            game.turn = null;
-            console.log(`[Game ${gameId}] Error on WS for ${connectingPlayerId}. State changed to 'opponent_disconnected'.`);
+        console.error(`[WS] Error for ${connectingPlayerId}@${gameId}:`, error);
+        if (player) player.ws = null;
+         if (game && ['battle', 'selecting_pokemon', 'waiting_for_other_player_selection', 'waiting_for_switch'].includes(game.state)) {
+            game.state = 'opponent_disconnected'; game.turn = null;
+            console.log(`[Game ${gameId}] Error on WS for ${connectingPlayerId}. State -> 'opponent_disconnected'.`);
             broadcastGameState(gameId);
         }
     });
 });
 
-// --- Express Routes --- (No changes to routes needed for this specific subtask)
-
+// --- Express Routes --- (No changes to routes for this subtask)
 app.post('/game', (req, res) => {
     const gameId = `game_${Date.now()}`;
     games[gameId] = { id: gameId, players: [], state: 'waiting_for_players', turn: null, winner: null };
@@ -180,27 +173,30 @@ app.post('/game/:id/join', (req, res) => {
     const game = games[gameId];
     let player = game.players.find(p => p.id === playerId);
 
-    if (player && player.ws && player.ws.readyState === WebSocket.OPEN) {
-        return res.status(400).json({ message: `Player ${playerId} already actively connected.` });
-    }
-    if (!player && game.players.length >= 2) {
-        return res.status(400).json({ message: 'Game is already full.' });
-    }
+    if (player && player.ws && player.ws.readyState === WebSocket.OPEN) return res.status(400).json({ message: `Player ${playerId} already actively connected.` });
+    if (!player && game.players.length >= 2) return res.status(400).json({ message: 'Game is already full.' });
     if (!playerId) return res.status(400).json({ message: 'Player ID required.' });
 
     if (!player) {
-         player = { id: playerId, pokemon: null, hasSelectedPokemon: false, ws: null };
+         player = {
+            id: playerId, party: [], activePokemonIndex: -1,
+            pokemonLeft: 0, hasSelectedParty: false, ws: null
+        };
          game.players.push(player);
-         console.log(`[Game ${gameId}] Player ${playerId} added to game`);
+         console.log(`[Game ${gameId}] Player ${playerId} added with new party structure.`);
     } else {
-        console.log(`[Game ${gameId}] Player ${playerId} re-confirmed in game.`);
+        console.log(`[Game ${gameId}] Player ${playerId} re-confirmed.`);
+        if (!player.party) player.party = [];
+        if (player.activePokemonIndex === undefined) player.activePokemonIndex = -1;
+        if (player.pokemonLeft === undefined) player.pokemonLeft = 0;
+        if (player.hasSelectedParty === undefined) player.hasSelectedParty = false;
     }
 
     let message = `Player ${playerId} in game ${gameId}.`;
     if (game.players.length === 2 && game.state === 'waiting_for_players') {
         game.state = 'selecting_pokemon';
-        message = `Both players joined. Game ready for Pokemon selection.`;
-        console.log(`[Game ${gameId}] State changed to 'selecting_pokemon'`);
+        message = `Both players joined. Ready for Pokemon selection.`;
+        console.log(`[Game ${gameId}] State -> 'selecting_pokemon'`);
     } else if (game.players.length < 2) {
         message = `Player ${playerId} joined. Waiting for opponent.`;
     }
@@ -211,56 +207,60 @@ app.post('/game/:id/join', (req, res) => {
 
 app.post('/game/:id/select-pokemon', (req, res) => {
     const gameId = req.params.id;
-    const { playerId, pokemonName } = req.body;
+    const { playerId, pokemonNames } = req.body;
 
     if (!games[gameId]) return res.status(404).json({ message: 'Game not found.' });
     const game = games[gameId];
-    if (game.state !== 'selecting_pokemon' && game.state !== 'opponent_disconnected') {
-        // Allow selection if opponent disconnected and player needs to re-select or was in selection
-        if (!(game.state === 'opponent_disconnected' && game.players.find(p => p.id === playerId && !p.hasSelectedPokemon))) {
-            return res.status(400).json({ message: 'Not in selection phase.' });
-        }
-    }
-
     const player = game.players.find(p => p.id === playerId);
+
     if (!player) return res.status(404).json({ message: 'Player not found.' });
-    if (player.hasSelectedPokemon && game.state !== 'opponent_disconnected') {
-        return res.status(400).json({ message: 'Already selected.' });
+    if (game.state !== 'selecting_pokemon' && !(game.state === 'opponent_disconnected' && !player.hasSelectedParty)) {
+        return res.status(400).json({ message: 'Not in selection phase or already selected.' });
     }
-    if (!pokemonName) return res.status(400).json({ message: 'Pokemon name required.' });
+    if (player.hasSelectedParty && game.state !== 'opponent_disconnected' ) {
+        return res.status(400).json({ message: 'Party already selected.' });
+    }
+    if (!Array.isArray(pokemonNames) || pokemonNames.length === 0 || pokemonNames.length > MAX_TEAM_SIZE) {
+        return res.status(400).json({ message: `Invalid team: Must be 1 to ${MAX_TEAM_SIZE} Pokemon.` });
+    }
 
-    const pokemonDetails = getPokemonDetails(pokemonName);
-    if (!pokemonDetails) return res.status(404).json({ message: `Pokemon ${pokemonName} not found.` });
+    const newParty = [];
+    for (const name of pokemonNames) {
+        const pokemonDetails = getPokemonDetails(name);
+        if (!pokemonDetails) return res.status(400).json({ message: `Invalid Pokemon name: ${name}.` });
+        newParty.push({
+            details: pokemonDetails, currentHp: pokemonDetails.stats.hp,
+            maxHp: pokemonDetails.stats.hp, status: 'healthy'
+        });
+    }
 
-    player.pokemon = { ...pokemonDetails, currentHp: pokemonDetails.stats.hp };
-    player.hasSelectedPokemon = true;
-    console.log(`[Game ${gameId}] Player ${playerId} selected ${pokemonName}`);
+    player.party = newParty;
+    player.activePokemonIndex = newParty.length > 0 ? 0 : -1;
+    player.pokemonLeft = newParty.length;
+    player.hasSelectedParty = true;
+    console.log(`[Game ${gameId}] Player ${playerId} selected party of ${newParty.length}.`);
 
-    let message = `Player ${playerId} selected ${pokemonName}.`;
-    const allPlayersSelected = game.players.every(p => p.hasSelectedPokemon);
+    let message = `Player ${playerId} selected their party.`;
+    const allPlayersSelected = game.players.every(p => p.hasSelectedParty);
 
-    if (game.state === 'opponent_disconnected') { // If one player selected while other was disconnected
+    if (game.state === 'opponent_disconnected') {
         const otherPlayer = game.players.find(p => p.id !== playerId);
-        if (otherPlayer && otherPlayer.ws && otherPlayer.ws.readyState === WebSocket.OPEN) { // If other player reconnected
+        if (otherPlayer && otherPlayer.ws && otherPlayer.ws.readyState === WebSocket.OPEN) {
             if (allPlayersSelected) {
                 game.state = 'battle';
-                game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
-                message = `All Pokemon selected after reconnection. Battle begins! It's ${game.turn}'s turn.`;
+                game.turn = game.players.find(p => p.id === playerId)?.id || game.players[0].id;
+                message = `All parties selected after reconnection. Battle begins! It's ${game.turn}'s turn.`;
             } else {
-                game.state = 'selecting_pokemon'; // Back to selection if other player still needs to select
-                message = `Player ${playerId} selected. Waiting for other player to select after reconnection.`;
+                game.state = 'selecting_pokemon';
+                message = `Player ${playerId} selected. Waiting for other player after reconnection.`;
             }
-        } else {
-             message += ` Waiting for opponent to reconnect.`; // Stay in opponent_disconnected or similar
-        }
+        } else { message += ` Waiting for opponent to reconnect.`; }
     } else if (allPlayersSelected) {
         game.state = 'battle';
-        game.turn = game.players[Math.floor(Math.random() * game.players.length)].id;
-        message = `All Pokemon selected. Battle begins! It's ${game.turn}'s turn.`;
-        console.log(`[Game ${gameId}] State changed to 'battle'. Turn: ${game.turn}`);
-    } else {
-        message += ` Waiting for other player.`;
-    }
+        game.turn = game.players[0].id;
+        message = `All parties selected. Battle begins! It's ${game.turn}'s turn.`;
+        console.log(`[Game ${gameId}] State -> 'battle'. Turn: ${game.turn}`);
+    } else { message += ` Waiting for other player.`; }
 
     broadcastGameState(gameId);
     res.json({ gameId, message, currentTurn: game.turn, currentGameState: game.state });
@@ -272,55 +272,71 @@ app.post('/game/:id/attack', (req, res) => {
 
     if (!games[gameId]) return res.status(404).json({ message: 'Game not found.' });
     const game = games[gameId];
+
     if (game.state !== 'battle') return res.status(400).json({ message: 'Not in battle phase.' });
     if (game.turn !== playerId) return res.status(400).json({ message: `Not player ${playerId}'s turn.` });
 
     const attackerPlayer = game.players.find(p => p.id === playerId);
     const defenderPlayer = game.players.find(p => p.id !== playerId);
 
-    if (!attackerPlayer?.pokemon || !defenderPlayer?.pokemon) {
-        return res.status(500).json({ message: 'Player or Pokemon data missing.' });
-    }
-    // Check if opponent is actually connected for an attack to be valid
+    if (!attackerPlayer || attackerPlayer.activePokemonIndex < 0 || !attackerPlayer.party[attackerPlayer.activePokemonIndex])
+        return res.status(500).json({ message: 'Attacker has no valid active Pokemon.' });
+    if (!defenderPlayer || defenderPlayer.activePokemonIndex < 0 || !defenderPlayer.party[defenderPlayer.activePokemonIndex])
+        return res.status(500).json({ message: 'Defender has no valid active Pokemon.' });
+
+    const attackerActivePokemon = attackerPlayer.party[attackerPlayer.activePokemonIndex];
+    const defenderActivePokemon = defenderPlayer.party[defenderPlayer.activePokemonIndex];
+
+    if (attackerActivePokemon.status === 'fainted')
+        return res.status(400).json({message: 'Your active Pokemon is fainted and cannot attack!'});
+    if (defenderActivePokemon.status === 'fainted')
+        return res.status(400).json({message: 'Opponent_s active Pokemon is already fainted! They should switch.'});
+
     if (!defenderPlayer.ws || defenderPlayer.ws.readyState !== WebSocket.OPEN) {
-        game.state = 'opponent_disconnected';
-        game.turn = null; // No one's turn
+        game.state = 'opponent_disconnected'; game.turn = null;
         broadcastGameState(gameId);
-        return res.status(400).json({ message: 'Opponent is not connected. Cannot attack.', currentGameState: game.state });
+        return res.status(400).json({ message: 'Opponent not connected. Cannot attack.', currentGameState: game.state });
     }
 
-    const attackerPokemon = attackerPlayer.pokemon;
-    const defenderPokemon = defenderPlayer.pokemon;
-    let damage = Math.max(1, Math.floor(attackerPokemon.stats.attack * (Math.random()*0.2 + 0.9)) - Math.floor(defenderPokemon.stats.defense * 0.5));
-    if (attackerPokemon.stats.attack > defenderPokemon.stats.defense / 2 && damage <= 0) damage = 1 + Math.floor(Math.random()*5);
+    let damage = Math.max(1, Math.floor(attackerActivePokemon.details.stats.attack * (Math.random()*0.2 + 0.9)) - Math.floor(defenderActivePokemon.details.stats.defense * 0.5));
+    if (attackerActivePokemon.details.stats.attack > defenderActivePokemon.details.stats.defense / 2 && damage <= 0) damage = 1 + Math.floor(Math.random()*5);
     else if (damage <= 0) damage = 1;
 
-    defenderPokemon.currentHp -= damage;
-    const usedAttack = attackName || "basic attack";
-    console.log(`[Game ${gameId}] ${playerId} (${attackerPokemon.name}) attacked ${defenderPlayer.id} (${defenderPokemon.name}) for ${damage}. Defender HP: ${defenderPokemon.currentHp}`);
+    defenderActivePokemon.currentHp -= damage;
+    const usedAttackName = attackName || "basic attack";
+    console.log(`[Game ${gameId}] ${playerId} (${attackerActivePokemon.details.name}) attacked ${defenderPlayer.id} (${defenderActivePokemon.details.name}) for ${damage}. Defender HP: ${defenderActivePokemon.currentHp}`);
 
     let message;
-    if (defenderPokemon.currentHp <= 0) {
-        defenderPokemon.currentHp = 0;
-        game.state = 'finished';
-        game.winner = playerId;
-        message = `${playerId} (${attackerPokemon.name}) wins! ${defenderPlayer.id}'s ${defenderPokemon.name} fainted.`;
-        console.log(`[Game ${gameId}] State changed to 'finished'. Winner: ${playerId}`);
+    if (defenderActivePokemon.currentHp <= 0) {
+        defenderActivePokemon.currentHp = 0;
+        defenderActivePokemon.status = 'fainted';
+        defenderPlayer.pokemonLeft = defenderPlayer.party.filter(p => p.status === 'healthy').length;
+
+        console.log(`[Game ${gameId}] ${defenderActivePokemon.details.name} fainted. ${defenderPlayer.id} has ${defenderPlayer.pokemonLeft} Pokemon left.`);
+
+        if (defenderPlayer.pokemonLeft <= 0) {
+            game.state = 'finished'; game.winner = attackerPlayer.id;
+            message = `${attackerPlayer.id} (${attackerActivePokemon.details.name}) wins! All of ${defenderPlayer.id}'s Pokemon have fainted.`;
+            console.log(`[Game ${gameId}] State -> 'finished'. Winner: ${attackerPlayer.id}`);
+        } else {
+            game.state = 'waiting_for_switch';
+            game.turn = defenderPlayer.id;
+            message = `${attackerActivePokemon.details.name} fainted ${defenderActivePokemon.details.name}! ${defenderPlayer.id} must switch Pokemon.`;
+            console.log(`[Game ${gameId}] State -> 'waiting_for_switch'. Turn: ${defenderPlayer.id}`);
+        }
     } else {
         game.turn = defenderPlayer.id;
-        message = `${playerId} (${attackerPokemon.name}) attacked. ${defenderPlayer.id}'s ${defenderPokemon.name} has ${defenderPokemon.currentHp} HP. Turn: ${defenderPlayer.id}.`;
+        message = `${attackerActivePokemon.details.name} attacked ${defenderActivePokemon.details.name} for ${damage} damage. ${defenderActivePokemon.details.name} has ${defenderActivePokemon.currentHp} HP. Turn: ${defenderPlayer.id}.`;
     }
 
     broadcastGameState(gameId);
-    res.json({ gameId, message, currentGameState: game.state, currentTurn: game.turn, winner: game.winner });
+    res.json({ gameId, message, currentGameState: game.state });
 });
 
 app.get('/game/:id', (req, res) => {
     const gameId = req.params.id;
     const sanitizedGameState = getSanitizedGameState(gameId);
-    if (!sanitizedGameState) {
-        return res.status(404).json({ message: 'Game not found.' });
-    }
+    if (!sanitizedGameState) return res.status(404).json({ message: 'Game not found.' });
     res.json(sanitizedGameState);
 });
 

--- a/pokemon-battle/src/components/BattleUI.css
+++ b/pokemon-battle/src/components/BattleUI.css
@@ -4,9 +4,15 @@
   background-color: #f0f0f0;
   border-radius: 10px;
   box-shadow: 0 0 15px rgba(0,0,0,0.1);
-  max-width: 700px;
+  max-width: 800px; /* Increased max-width for party display */
   margin: 20px auto;
   text-align: center;
+}
+
+.battle-loading-message {
+  padding: 20px;
+  font-size: 1.2em;
+  color: #555;
 }
 
 .battle-title {
@@ -17,15 +23,15 @@
 .turn-indicator {
   font-size: 1.2em;
   font-weight: bold;
-  color: #d35400; /* Orange color for turns */
-  margin-bottom: 20px;
+  color: #d35400;
+  margin-bottom: 15px;
 }
 
 .pokemon-display-area {
   display: flex;
   justify-content: space-around;
-  align-items: flex-start; /* Align items to the top */
-  margin-bottom: 30px;
+  align-items: flex-start;
+  margin-bottom: 25px;
 }
 
 .pokemon-card {
@@ -33,58 +39,70 @@
   border: 1px solid #ddd;
   border-radius: 8px;
   padding: 15px;
-  width: 45%; /* Each card takes about 45% of the width */
+  width: 48%; /* Adjusted width */
   box-shadow: 0 2px 4px rgba(0,0,0,0.05);
   transition: transform 0.2s ease-in-out, box-shadow 0.2s ease-in-out;
+  display: flex;
+  flex-direction: column;
+  align-items: center; /* Center items in card */
 }
 
-.pokemon-card.active-turn {
-  border-color: #3498db; /* Blue border for active turn */
-  box-shadow: 0 0 10px rgba(52, 152, 219, 0.5);
-  transform: scale(1.02);
+.pokemon-card.active-turn-battle { /* More specific class for battle turn */
+  border-color: #2980b9; /* Darker blue for active turn */
+  box-shadow: 0 0 12px rgba(41, 128, 185, 0.6);
+  transform: scale(1.03);
 }
 
 .pokemon-card h3 {
   margin-top: 0;
-  margin-bottom: 5px;
+  margin-bottom: 10px; /* Increased margin */
   font-size: 1.1em;
   color: #555;
 }
 
-.pokemon-card h4 { /* Pokemon Name */
+.pokemon-card h4 {
   margin-top: 5px;
-  margin-bottom: 10px;
+  margin-bottom: 8px;
   font-size: 1.3em;
   color: #333;
 }
 
+.pokemon-status-ingame {
+    font-size: 0.7em;
+    font-style: italic;
+    color: #666;
+    vertical-align: middle;
+}
+
 .pokemon-sprite {
-  width: 96px; /* Standard sprite size */
-  height: 96px;
-  margin-bottom: 10px;
-  image-rendering: pixelated; /* Keep sprites crisp */
-  background-color: #eee;
+  width: 110px; /* Slightly larger sprite */
+  height: 110px;
+  margin-bottom: 8px;
+  image-rendering: pixelated;
+  background-color: #f0f0f0; /* Light background for sprite */
+  border: 1px solid #ccc;
   border-radius: 5px;
 }
 
 .hp-bar-container {
   background-color: #e0e0e0;
   border-radius: 5px;
-  height: 20px;
+  height: 22px; /* Slightly thicker */
+  width: 80%; /* Relative to card width */
   margin-bottom: 5px;
-  overflow: hidden; /* Ensures the inner bar doesn't overflow */
-  border: 1px solid #ccc;
+  overflow: hidden;
+  border: 1px solid #bbb;
 }
 
 .hp-bar {
   height: 100%;
-  background-color: #2ecc71; /* Green for HP */
-  border-radius: 3px; /* Slightly less than container for nice effect */
+  background-color: #2ecc71;
+  border-radius: 3px;
   transition: width 0.5s ease-in-out;
 }
 
 .hp-bar.opponent-hp-bar {
-  background-color: #e74c3c; /* Red for opponent HP, or keep green if preferred */
+  background-color: #e74c3c;
 }
 
 .hp-text {
@@ -97,19 +115,20 @@
 .stats-text {
   font-size: 0.8em;
   color: #666;
+  margin-bottom: 10px; /* Added margin */
 }
 
 .vs-separator {
   display: flex;
   align-items: center;
-  font-size: 2em;
+  font-size: 2.5em; /* Larger VS */
   font-weight: bold;
-  color: #7f8c8d; /* Greyish color for VS */
-  padding: 0 10px; /* Add some padding */
+  color: #7f8c8d;
+  padding: 0 5px; /* Reduced padding as cards are wider */
 }
 
 .attack-button {
-  background-color: #e74c3c; /* Red color for attack */
+  background-color: #e74c3c;
   color: white;
   border: none;
   padding: 12px 25px;
@@ -118,31 +137,126 @@
   cursor: pointer;
   transition: background-color 0.2s;
   box-shadow: 0 2px 5px rgba(0,0,0,0.1);
+  margin-top: 10px; /* Added margin */
 }
 
-.attack-button:hover {
-  background-color: #c0392b; /* Darker red on hover */
+.attack-button:hover:not(:disabled) {
+  background-color: #c0392b;
 }
 
 .attack-button:disabled {
-  background-color: #bdc3c7; /* Grey when disabled */
+  background-color: #bdc3c7;
   cursor: not-allowed;
 }
 
 .game-over-message {
   margin-top: 20px;
-  padding: 15px;
+  padding: 20px; /* Increased padding */
   background-color: #ecf0f1;
-  border-radius: 5px;
+  border-radius: 8px; /* Softer radius */
   border: 1px solid #bdc3c7;
 }
 
 .game-over-message h3 {
   color: #2c3e50;
   margin-bottom: 10px;
+  font-size: 1.5em; /* Larger game over text */
 }
 
-.game-over-message p {
-  font-size: 1.1em;
-  color: #34495e;
+.opponent-disconnected-message {
+    margin-top: 20px;
+    padding: 15px;
+    background-color: #fff3cd; /* Light yellow */
+    border: 1px solid #ffeeba;
+    color: #856404;
+    border-radius: 5px;
+}
+
+.pokemon-placeholder {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    height: 150px; /* Adjust as needed */
+    color: #999;
+    font-style: italic;
+}
+
+
+/* Party Status Display */
+.party-status-display {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  margin-bottom: 10px; /* Space below pokeballs */
+  height: 30px; /* Fixed height for alignment */
+}
+
+.pokeball-icon {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  border: 2px solid #333;
+  margin: 0 3px;
+  background-color: #fff; /* Default empty or base color */
+  position: relative;
+  display: inline-block;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.2);
+}
+
+/* Simulating Pokeball design */
+.pokeball-icon::before {
+  content: '';
+  position: absolute;
+  top: calc(50% - 1px); /* Center line */
+  left: 0;
+  right: 0;
+  height: 2px;
+  background-color: #333;
+}
+
+.pokeball-icon::after {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 6px; /* Inner circle */
+  height: 6px;
+  border-radius: 50%;
+  background-color: #fff;
+  border: 1px solid #333;
+  transform: translate(-50%, -50%);
+  box-sizing: border-box;
+}
+
+.pokeball-icon.healthy {
+  background-color: #e74c3c; /* Top half red */
+  background: linear-gradient(to bottom, #e74c3c 0%, #e74c3c 48%, #fff 48%, #fff 52%, #fff 52%, #fff 100%);
+}
+.pokeball-icon.healthy::after {
+   background-color: #fff; /* White button for healthy */
+}
+
+
+.pokeball-icon.fainted {
+  background-color: #7f8c8d; /* Grey for fainted */
+  opacity: 0.6;
+}
+.pokeball-icon.fainted::after {
+  background-color: #bdc3c7; /* Darker grey button for fainted */
+}
+
+.pokeball-icon.empty {
+  background-color: #ecf0f1; /* Light grey for empty slot */
+  border-color: #bdc3c7;
+}
+.pokeball-icon.empty::before,
+.pokeball-icon.empty::after {
+  border-color: #bdc3c7;
+}
+
+
+.pokeball-icon.active {
+  border-color: #f1c40f; /* Gold border for active */
+  box-shadow: 0 0 8px #f1c40f;
+  transform: scale(1.2); /* Slightly larger */
 }

--- a/pokemon-battle/src/components/BattleUI.jsx
+++ b/pokemon-battle/src/components/BattleUI.jsx
@@ -1,74 +1,151 @@
 import React from 'react';
-import './BattleUI.css'; // We'll create this for styling
+import './BattleUI.css';
+
+const MAX_TEAM_SIZE_DISPLAY = 6; // For rendering empty slots if team is smaller
+
+// Helper component for Pokeball icons
+const PokeballIcon = ({ status, isActive }) => {
+  let ballClass = 'pokeball-icon';
+  if (status === 'fainted') ballClass += ' fainted';
+  else if (status === 'healthy') ballClass += ' healthy';
+  else ballClass += ' empty'; // For empty slots in party
+
+  if (isActive) ballClass += ' active';
+
+  return <div className={ballClass} title={isActive ? `Active: ${status}` : status}></div>;
+};
+
+// Helper component for displaying a player's party status
+const PartyStatusDisplay = ({ party, activePokemonIndex }) => {
+  const partySlots = [];
+  for (let i = 0; i < MAX_TEAM_SIZE_DISPLAY; i++) {
+    const pokemon = party?.[i]; // Use optional chaining in case party is not fully populated
+    partySlots.push(
+      <PokeballIcon
+        key={i}
+        status={pokemon ? pokemon.status : 'empty'}
+        isActive={i === activePokemonIndex && pokemon && pokemon.status !== 'fainted'} // Active only if not fainted
+      />
+    );
+  }
+  return <div className="party-status-display">{partySlots}</div>;
+};
+
 
 function BattleUI({ gameData, playerId, onAttack, isLoading }) {
   if (!gameData || !gameData.players || gameData.players.length < 2) {
-    return <p>Waiting for game data or opponent...</p>;
+    return <p className="battle-loading-message">Waiting for full game data or opponent...</p>;
   }
 
   const playerInfo = gameData.players.find(p => p.id === playerId);
   const opponentInfo = gameData.players.find(p => p.id !== playerId);
 
-  if (!playerInfo || !playerInfo.pokemon) {
-    return <p>Waiting for your Pokemon data...</p>;
+  // Validate essential data before trying to render
+  if (!playerInfo || !playerInfo.party || playerInfo.activePokemonIndex == null || playerInfo.activePokemonIndex < 0) {
+    return <p className="battle-loading-message">Waiting for your player data to fully load...</p>;
   }
-  if (!opponentInfo || !opponentInfo.pokemon) {
-    return <p>Waiting for opponent's Pokemon data...</p>;
+  if (!opponentInfo || !opponentInfo.party || opponentInfo.activePokemonIndex == null || opponentInfo.activePokemonIndex < 0 ) {
+    // Opponent might not have selected party yet, or data is still loading
+     // Check if opponent has selected party, if not, show different message
+     if (!opponentInfo.hasSelectedParty && gameData.state === 'selecting_pokemon') {
+        return <p className="battle-loading-message">Waiting for opponent to select their team...</p>;
+    }
+    return <p className="battle-loading-message">Waiting for opponent's data to fully load...</p>;
   }
 
-  const playerPokemon = playerInfo.pokemon;
-  const opponentPokemon = opponentInfo.pokemon;
+  const playerActivePokemon = playerInfo.party[playerInfo.activePokemonIndex];
+  const opponentActivePokemon = opponentInfo.party[opponentInfo.activePokemonIndex];
+
+  if (!playerActivePokemon || !playerActivePokemon.details) {
+    return <p className="battle-loading-message">Your active Pokémon data is missing. Game state: {gameData.state}</p>;
+  }
+   if (!opponentActivePokemon || !opponentActivePokemon.details) {
+    // This can happen if opponent's active Pokemon fainted and they are in 'waiting_for_switch'
+    if (gameData.state === 'waiting_for_switch' && gameData.turn === opponentInfo.id) {
+        // UI should show opponent is switching, BattleUI might not be the primary view then
+        // or it shows a placeholder for opponent's active Pokemon.
+    } else if (gameData.state !== 'finished'){ // Don't show error if game is finished
+       return <p className="battle-loading-message">Opponent's active Pokémon data is missing. Game state: {gameData.state}</p>;
+    }
+  }
+
 
   const getHPRatio = (currentHp, maxHp) => {
-    if (maxHp === 0) return 0;
-    return (currentHp / maxHp) * 100;
+    if (!maxHp || maxHp === 0) return 0; // Prevent division by zero
+    return Math.max(0, (currentHp / maxHp) * 100); // Ensure HP doesn't go below 0% visual
   };
+
+  const canAttack = gameData.state === 'battle' &&
+                    gameData.turn === playerId &&
+                    playerActivePokemon && playerActivePokemon.status !== 'fainted' &&
+                    opponentActivePokemon && opponentActivePokemon.status !== 'fainted';
 
   return (
     <div className="battle-container">
-      <h2 className="battle-title">Battle In Progress!</h2>
-      <p className="turn-indicator">
-        {gameData.turn === playerId ? "Your Turn" : `Opponent's Turn (${gameData.turn})`}
-      </p>
+      <h2 className="battle-title">
+        {gameData.state === 'finished' ? 'Game Over!' : 'Battle In Progress!'}
+      </h2>
+
+      {gameData.state !== 'finished' && (
+        <p className="turn-indicator">
+          {gameData.turn === playerId ? "Your Turn" : (gameData.turn ? `Opponent's Turn (${gameData.turn})` : "Waiting...")}
+        </p>
+      )}
+
 
       <div className="pokemon-display-area">
-        {/* Player's Pokemon */}
-        <div className={`pokemon-card player-card ${gameData.turn === playerId ? 'active-turn' : ''}`}>
+        {/* Player's Side */}
+        <div className={`pokemon-card player-card ${gameData.turn === playerId && gameData.state === 'battle' ? 'active-turn-battle' : ''}`}>
           <h3>You ({playerInfo.id})</h3>
-          <img src={playerPokemon.sprite} alt={playerPokemon.name} className="pokemon-sprite" />
-          <h4>{playerPokemon.name}</h4>
-          <div className="hp-bar-container">
-            <div
-              className="hp-bar"
-              style={{ width: `${getHPRatio(playerPokemon.currentHp, playerPokemon.stats.hp)}%` }}
-            ></div>
-          </div>
-          <p className="hp-text">HP: {playerPokemon.currentHp} / {playerPokemon.stats.hp}</p>
-          <p className="stats-text">Atk: {playerPokemon.stats.attack} / Def: {playerPokemon.stats.defense}</p>
+          <PartyStatusDisplay party={playerInfo.party} activePokemonIndex={playerInfo.activePokemonIndex} />
+          {playerActivePokemon && playerActivePokemon.details && (
+            <>
+              <img src={playerActivePokemon.details.sprite} alt={playerActivePokemon.details.name} className="pokemon-sprite" />
+              <h4>{playerActivePokemon.details.name} <span className="pokemon-status-ingame">({playerActivePokemon.status})</span></h4>
+              <div className="hp-bar-container">
+                <div
+                  className="hp-bar"
+                  style={{ width: `${getHPRatio(playerActivePokemon.currentHp, playerActivePokemon.maxHp)}%` }}
+                ></div>
+              </div>
+              <p className="hp-text">HP: {playerActivePokemon.currentHp} / {playerActivePokemon.maxHp}</p>
+              <p className="stats-text">Atk: {playerActivePokemon.details.stats.attack} / Def: {playerActivePokemon.details.stats.defense}</p>
+            </>
+          )}
         </div>
 
         <div className="vs-separator">VS</div>
 
-        {/* Opponent's Pokemon */}
-        <div className={`pokemon-card opponent-card ${gameData.turn !== playerId ? 'active-turn' : ''}`}>
+        {/* Opponent's Side */}
+        <div className={`pokemon-card opponent-card ${gameData.turn !== playerId && gameData.state === 'battle' ? 'active-turn-battle' : ''}`}>
           <h3>Opponent ({opponentInfo.id})</h3>
-          <img src={opponentPokemon.sprite} alt={opponentPokemon.name} className="pokemon-sprite" />
-          <h4>{opponentPokemon.name}</h4>
-          <div className="hp-bar-container">
-            <div
-              className="hp-bar opponent-hp-bar"
-              style={{ width: `${getHPRatio(opponentPokemon.currentHp, opponentPokemon.stats.hp)}%` }}
-            ></div>
-          </div>
-          <p className="hp-text">HP: {opponentPokemon.currentHp} / {opponentPokemon.stats.hp}</p>
-           <p className="stats-text">Atk: {opponentPokemon.stats.attack} / Def: {opponentPokemon.stats.defense}</p>
+          <PartyStatusDisplay party={opponentInfo.party} activePokemonIndex={opponentInfo.activePokemonIndex} />
+          {opponentActivePokemon && opponentActivePokemon.details ? (
+            <>
+              <img src={opponentActivePokemon.details.sprite} alt={opponentActivePokemon.details.name} className="pokemon-sprite" />
+              <h4>{opponentActivePokemon.details.name} <span className="pokemon-status-ingame">({opponentActivePokemon.status})</span></h4>
+              <div className="hp-bar-container">
+                <div
+                  className="hp-bar opponent-hp-bar"
+                  style={{ width: `${getHPRatio(opponentActivePokemon.currentHp, opponentActivePokemon.maxHp)}%` }}
+                ></div>
+              </div>
+              <p className="hp-text">HP: {opponentActivePokemon.currentHp} / {opponentActivePokemon.maxHp}</p>
+              <p className="stats-text">Atk: {opponentActivePokemon.details.stats.attack} / Def: {opponentActivePokemon.details.stats.defense}</p>
+            </>
+          ) : (
+            <div className="pokemon-placeholder">
+                <p>Waiting for opponent's Pokemon...</p>
+                {/* Or show a question mark sprite */}
+            </div>
+          )}
         </div>
       </div>
 
       {gameData.state === 'battle' && gameData.turn === playerId && (
         <button
           onClick={onAttack}
-          disabled={isLoading}
+          disabled={isLoading || !canAttack}
           className="attack-button"
         >
           {isLoading ? 'Attacking...' : 'Attack!'}
@@ -77,8 +154,12 @@ function BattleUI({ gameData, playerId, onAttack, isLoading }) {
 
       {gameData.state === 'finished' && (
         <div className="game-over-message">
-          <h3>Game Over!</h3>
-          <p>{gameData.winner === playerId ? "Congratulations, you won!" : "You lost. Better luck next time!"}</p>
+          <h3>{gameData.winner === playerId ? "🎉 Congratulations, you won! 🎉" : "💔 You lost. Better luck next time! 💔"}</h3>
+        </div>
+      )}
+       {gameData.state === 'opponent_disconnected' && (
+        <div className="opponent-disconnected-message">
+            <p>Opponent has disconnected. Waiting for them to rejoin...</p>
         </div>
       )}
     </div>

--- a/pokemon-battle/src/components/PokemonSwitchUI.css
+++ b/pokemon-battle/src/components/PokemonSwitchUI.css
@@ -1,0 +1,108 @@
+.switch-ui-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: rgba(0, 0, 0, 0.75);
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  z-index: 1000; /* Ensure it's on top */
+  padding: 20px;
+}
+
+.switch-ui-modal {
+  background-color: white;
+  padding: 25px;
+  border-radius: 10px;
+  box-shadow: 0 5px 15px rgba(0,0,0,0.3);
+  text-align: center;
+  max-width: 90%;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.switch-ui-modal h2 {
+  margin-top: 0;
+  color: #c0392b; /* Reddish color for urgency */
+}
+
+.switch-ui-modal p {
+  margin-bottom: 20px;
+  font-size: 1.1em;
+}
+
+.pokemon-options-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+  gap: 15px;
+  justify-content: center;
+}
+
+.pokemon-option {
+  border: 2px solid #ddd;
+  border-radius: 8px;
+  padding: 10px;
+  cursor: pointer;
+  transition: transform 0.2s, box-shadow 0.2s, border-color 0.2s;
+  background-color: #f9f9f9;
+}
+
+.pokemon-option:hover:not(.disabled) {
+  transform: translateY(-5px);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+  border-color: #3498db; /* Blue border on hover */
+}
+
+.pokemon-option.disabled {
+  background-color: #e0e0e0;
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.pokemon-option.disabled:hover {
+  transform: none;
+  box-shadow: none;
+  border-color: #ddd;
+}
+
+.pokemon-option.just-fainted,
+.pokemon-option.active-cannot-switch { /* Style for the one that just fainted or is active but shouldn't be chosen */
+  border-color: #c0392b;
+  opacity: 0.7;
+  cursor: not-allowed; /* Should already be handled by disabled but good to reinforce */
+}
+
+
+.pokemon-sprite-option {
+  width: 80px;
+  height: 80px;
+  margin-bottom: 8px;
+  image-rendering: pixelated;
+  background-color: #eee;
+  border-radius: 4px;
+}
+
+.pokemon-name-option {
+  font-weight: bold;
+  font-size: 1em;
+  margin-bottom: 4px;
+}
+
+.pokemon-hp-option {
+  font-size: 0.85em;
+  color: #555;
+  margin-bottom: 4px;
+}
+
+.pokemon-status-fainted {
+  font-size: 0.8em;
+  color: #c0392b;
+  font-style: italic;
+}
+.pokemon-status-active {
+  font-size: 0.8em;
+  color: #7f8c8d;
+  font-style: italic;
+}

--- a/pokemon-battle/src/components/PokemonSwitchUI.jsx
+++ b/pokemon-battle/src/components/PokemonSwitchUI.jsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import './PokemonSwitchUI.css'; // Create this file for styling
+
+function PokemonSwitchUI({ playerParty, onPokemonSwitchSelected, activePokemonIndex }) {
+  if (!playerParty || playerParty.length === 0) {
+    return (
+      <div className="switch-ui-overlay">
+        <div className="switch-ui-modal">
+          <h2>Error: No Pokemon in Party</h2>
+          <p>Cannot switch Pokemon as your party is empty.</p>
+        </div>
+      </div>
+    );
+  }
+
+  const availableToSwitch = playerParty.filter((pokemon, index) =>
+    pokemon.status !== 'fainted' && index !== activePokemonIndex
+  );
+
+  return (
+    <div className="switch-ui-overlay">
+      <div className="switch-ui-modal">
+        <h2>Your Pokemon Fainted!</h2>
+        <p>Choose your next Pokemon to send into battle:</p>
+        {availableToSwitch.length === 0 ? (
+          <p>No other Pokemon available to switch to!</p>
+        ) : (
+          <div className="pokemon-options-grid">
+            {playerParty.map((pokemon, index) => {
+              const isFainted = pokemon.status === 'fainted';
+              const isActive = index === activePokemonIndex; // The one that just fainted (or is currently active but needs switch)
+
+              // Do not allow selecting the currently active Pokemon (which just fainted) or other fainted Pokemon
+              const isDisabled = isFainted || isActive;
+
+              return (
+                <div
+                  key={pokemon.details.id || index} // Use a stable key
+                  className={`pokemon-option ${isDisabled ? 'disabled' : ''} ${isActive ? 'just-fainted' : ''}`}
+                  onClick={() => !isDisabled && onPokemonSwitchSelected(index)}
+                >
+                  <img
+                    src={pokemon.details.sprite}
+                    alt={pokemon.details.name}
+                    className="pokemon-sprite-option"
+                  />
+                  <p className="pokemon-name-option">{pokemon.details.name}</p>
+                  <p className="pokemon-hp-option">
+                    HP: {pokemon.currentHp} / {pokemon.maxHp}
+                  </p>
+                  {isFainted && <p className="pokemon-status-fainted">(Fainted)</p>}
+                  {isActive && !isFainted && <p className="pokemon-status-active">(Currently Active - Cannot Switch To)</p>}
+                   {isActive && isFainted && <p className="pokemon-status-active">(Just Fainted)</p>}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PokemonSwitchUI;


### PR DESCRIPTION
This major feature updates the game to a 6-Pokemon team format, including mechanics for Pokemon fainting and player switching.

Backend (`pokemon-battle-backend`):
- Data structures updated to support a 'party' of up to 6 Pokemon per player, each with details, current HP, max HP, and status ('healthy', 'fainted').
- Player objects now track `activePokemonIndex` and `pokemonLeft`.
- Pokemon selection endpoint (`POST /game/:id/select-pokemon`) now accepts a team of up to 6 Pokemon.
- Attack logic (`POST /game/:id/attack`) updated:
    - Targets active Pokemon in the party.
    - Handles HP updates and sets 'fainted' status.
    - Decrements `pokemonLeft` counter.
    - Transitions game to 'waiting_for_switch' state if a Pokemon faints and you have others available, giving turn to you.
    - Checks for win condition (all 6 opponent Pokemon fainted).
- New WebSocket message type `switchPokemon` implemented for players to choose their next active Pokemon. Includes validation for state, turn, and valid Pokemon choice. Transitions game back to 'battle' and gives turn to the opponent.
- Game state broadcasting updated for new party structures and states.

Frontend (`pokemon-battle`):
- `PokemonSelection.jsx` UI updated to allow selection of a team of up to 6 Pokemon, displaying the selected team.
- `App.jsx` updated to handle team submission and new game states.
- `BattleUI.jsx` significantly updated:
    - Displays party status for both players using Pokeball icons, indicating 'healthy', 'fainted', and 'active' Pokemon.
    - Active Pokemon display (sprite, name, HP) now sources data from the active Pokemon in the party.
- New `PokemonSwitchUI.jsx` component (modal) created:
    - Appears when `gameState` is 'waiting_for_switch' for you.
    - Allows you to select your next non-fainted Pokemon.
    - Sends `switchPokemon` WebSocket message to the backend.

This provides a more strategic and engaging Pokemon battle experience.