### PR TITLE
feat: Phase 2 - Expand Pokemon Data

### DIFF
--- a/pokemon-battle-backend/package.json
+++ b/pokemon-battle-backend/package.json
@@ -5,13 +5,17 @@
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "fetch-pokemon-data": "node scripts/fetchPokemonData.js"
   },
   "dependencies": {
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",
     "express": "^4.17.1",
     "ws": "^8.17.0"
+  },
+  "devDependencies": {
+    "axios": "^1.6.0"
   },
   "author": "",
   "license": "ISC"

--- a/pokemon-battle-backend/pokemonData.js
+++ b/pokemon-battle-backend/pokemonData.js
@@ -1,65 +1,318 @@
+// pokemonData.js
+// Manually curated dataset with a wider variety of Pokemon (Gen 1 & 2 focus)
+// Structure: id, name (lowercase), stats (hp, attack, defense, specialAttack, specialDefense, speed), types (array), sprite URL
+
 const POKEMON_DATA = {
-    'Bulbasaur': {
-        id: 1, name: 'Bulbasaur', type: ['Grass', 'Poison'],
-        stats: { hp: 45, attack: 49, defense: 49, speed: 45 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png'
-    },
-    'Charmander': {
-        id: 4, name: 'Charmander', type: ['Fire'],
-        stats: { hp: 39, attack: 52, defense: 43, speed: 65 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png'
-    },
-    'Squirtle': {
-        id: 7, name: 'Squirtle', type: ['Water'],
-        stats: { hp: 44, attack: 48, defense: 65, speed: 43 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png'
-    },
-    'Pikachu': {
-        id: 25, name: 'Pikachu', type: ['Electric'],
-        stats: { hp: 35, attack: 55, defense: 40, speed: 90 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png'
-    },
-    'Jigglypuff': {
-        id: 39, name: 'Jigglypuff', type: ['Normal', 'Fairy'],
-        stats: { hp: 115, attack: 45, defense: 20, speed: 20 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/39.png'
-    },
-    'Meowth': {
-        id: 52, name: 'Meowth', type: ['Normal'],
-        stats: { hp: 40, attack: 45, defense: 35, speed: 90 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/52.png'
-    },
-    'Machop': {
-        id: 66, name: 'Machop', type: ['Fighting'],
-        stats: { hp: 70, attack: 80, defense: 50, speed: 35 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/66.png'
-    },
-    'Geodude': {
-        id: 74, name: 'Geodude', type: ['Rock', 'Ground'],
-        stats: { hp: 40, attack: 80, defense: 100, speed: 20 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/74.png'
-    },
-    'Gastly': {
-        id: 92, name: 'Gastly', type: ['Ghost', 'Poison'],
-        stats: { hp: 30, attack: 35, defense: 30, speed: 80 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/92.png'
-    },
-    'Eevee': {
-        id: 133, name: 'Eevee', type: ['Normal'],
-        stats: { hp: 55, attack: 55, defense: 50, speed: 55 },
-        sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/133.png'
-    }
+  "bulbasaur": {
+    "id": 1, "name": "bulbasaur",
+    "stats": { "hp": 45, "attack": 49, "defense": 49, "specialAttack": 65, "specialDefense": 65, "speed": 45 },
+    "types": ["grass", "poison"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/1.png"
+  },
+  "ivysaur": {
+    "id": 2, "name": "ivysaur",
+    "stats": { "hp": 60, "attack": 62, "defense": 63, "specialAttack": 80, "specialDefense": 80, "speed": 60 },
+    "types": ["grass", "poison"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/2.png"
+  },
+  "venusaur": {
+    "id": 3, "name": "venusaur",
+    "stats": { "hp": 80, "attack": 82, "defense": 83, "specialAttack": 100, "specialDefense": 100, "speed": 80 },
+    "types": ["grass", "poison"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/3.png"
+  },
+  "charmander": {
+    "id": 4, "name": "charmander",
+    "stats": { "hp": 39, "attack": 52, "defense": 43, "specialAttack": 60, "specialDefense": 50, "speed": 65 },
+    "types": ["fire"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/4.png"
+  },
+  "charmeleon": {
+    "id": 5, "name": "charmeleon",
+    "stats": { "hp": 58, "attack": 64, "defense": 58, "specialAttack": 80, "specialDefense": 65, "speed": 80 },
+    "types": ["fire"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/5.png"
+  },
+  "charizard": {
+    "id": 6, "name": "charizard",
+    "stats": { "hp": 78, "attack": 84, "defense": 78, "specialAttack": 109, "specialDefense": 85, "speed": 100 },
+    "types": ["fire", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/6.png"
+  },
+  "squirtle": {
+    "id": 7, "name": "squirtle",
+    "stats": { "hp": 44, "attack": 48, "defense": 65, "specialAttack": 50, "specialDefense": 64, "speed": 43 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/7.png"
+  },
+  "wartortle": {
+    "id": 8, "name": "wartortle",
+    "stats": { "hp": 59, "attack": 63, "defense": 80, "specialAttack": 65, "specialDefense": 80, "speed": 58 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/8.png"
+  },
+  "blastoise": {
+    "id": 9, "name": "blastoise",
+    "stats": { "hp": 79, "attack": 83, "defense": 100, "specialAttack": 85, "specialDefense": 105, "speed": 78 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/9.png"
+  },
+  "caterpie": {
+    "id": 10, "name": "caterpie",
+    "stats": { "hp": 45, "attack": 30, "defense": 35, "specialAttack": 20, "specialDefense": 20, "speed": 45 },
+    "types": ["bug"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/10.png"
+  },
+  "metapod": {
+    "id": 11, "name": "metapod",
+    "stats": { "hp": 50, "attack": 20, "defense": 55, "specialAttack": 25, "specialDefense": 25, "speed": 30 },
+    "types": ["bug"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/11.png"
+  },
+  "butterfree": {
+    "id": 12, "name": "butterfree",
+    "stats": { "hp": 60, "attack": 45, "defense": 50, "specialAttack": 90, "specialDefense": 80, "speed": 70 },
+    "types": ["bug", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/12.png"
+  },
+  "pidgey": {
+    "id": 16, "name": "pidgey",
+    "stats": { "hp": 40, "attack": 45, "defense": 40, "specialAttack": 35, "specialDefense": 35, "speed": 56 },
+    "types": ["normal", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/16.png"
+  },
+  "pidgeotto": {
+    "id": 17, "name": "pidgeotto",
+    "stats": { "hp": 63, "attack": 60, "defense": 55, "specialAttack": 50, "specialDefense": 50, "speed": 71 },
+    "types": ["normal", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/17.png"
+  },
+  "pidgeot": {
+    "id": 18, "name": "pidgeot",
+    "stats": { "hp": 83, "attack": 80, "defense": 75, "specialAttack": 70, "specialDefense": 70, "speed": 101 },
+    "types": ["normal", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/18.png"
+  },
+  "pikachu": {
+    "id": 25, "name": "pikachu",
+    "stats": { "hp": 35, "attack": 55, "defense": 40, "specialAttack": 50, "specialDefense": 50, "speed": 90 },
+    "types": ["electric"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/25.png"
+  },
+  "raichu": {
+    "id": 26, "name": "raichu",
+    "stats": { "hp": 60, "attack": 90, "defense": 55, "specialAttack": 90, "specialDefense": 80, "speed": 110 },
+    "types": ["electric"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/26.png"
+  },
+  "jigglypuff": {
+    "id": 39, "name": "jigglypuff",
+    "stats": { "hp": 115, "attack": 45, "defense": 20, "specialAttack": 45, "specialDefense": 25, "speed": 20 },
+    "types": ["normal", "fairy"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/39.png"
+  },
+  "wigglytuff": {
+    "id": 40, "name": "wigglytuff",
+    "stats": { "hp": 140, "attack": 70, "defense": 45, "specialAttack": 85, "specialDefense": 50, "speed": 45 },
+    "types": ["normal", "fairy"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/40.png"
+  },
+  "abra": {
+    "id": 63, "name": "abra",
+    "stats": { "hp": 25, "attack": 20, "defense": 15, "specialAttack": 105, "specialDefense": 55, "speed": 90 },
+    "types": ["psychic"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/63.png"
+  },
+  "kadabra": {
+    "id": 64, "name": "kadabra",
+    "stats": { "hp": 40, "attack": 35, "defense": 30, "specialAttack": 120, "specialDefense": 70, "speed": 105 },
+    "types": ["psychic"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/64.png"
+  },
+  "alakazam": {
+    "id": 65, "name": "alakazam",
+    "stats": { "hp": 55, "attack": 50, "defense": 45, "specialAttack": 135, "specialDefense": 95, "speed": 120 },
+    "types": ["psychic"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/65.png"
+  },
+  "gastly": {
+    "id": 92, "name": "gastly",
+    "stats": { "hp": 30, "attack": 35, "defense": 30, "specialAttack": 100, "specialDefense": 35, "speed": 80 },
+    "types": ["ghost", "poison"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/92.png"
+  },
+  "haunter": {
+    "id": 93, "name": "haunter",
+    "stats": { "hp": 45, "attack": 50, "defense": 45, "specialAttack": 115, "specialDefense": 55, "speed": 95 },
+    "types": ["ghost", "poison"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/93.png"
+  },
+  "gengar": {
+    "id": 94, "name": "gengar",
+    "stats": { "hp": 60, "attack": 65, "defense": 60, "specialAttack": 130, "specialDefense": 75, "speed": 110 },
+    "types": ["ghost", "poison"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/94.png"
+  },
+  "eevee": {
+    "id": 133, "name": "eevee",
+    "stats": { "hp": 55, "attack": 55, "defense": 50, "specialAttack": 45, "specialDefense": 65, "speed": 55 },
+    "types": ["normal"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/133.png"
+  },
+  "vaporeon": {
+    "id": 134, "name": "vaporeon",
+    "stats": { "hp": 130, "attack": 65, "defense": 60, "specialAttack": 110, "specialDefense": 95, "speed": 65 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/134.png"
+  },
+  "jolteon": {
+    "id": 135, "name": "jolteon",
+    "stats": { "hp": 65, "attack": 65, "defense": 60, "specialAttack": 110, "specialDefense": 95, "speed": 130 },
+    "types": ["electric"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/135.png"
+  },
+  "flareon": {
+    "id": 136, "name": "flareon",
+    "stats": { "hp": 65, "attack": 130, "defense": 60, "specialAttack": 95, "specialDefense": 110, "speed": 65 },
+    "types": ["fire"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/136.png"
+  },
+  "snorlax": {
+    "id": 143, "name": "snorlax",
+    "stats": { "hp": 160, "attack": 110, "defense": 65, "specialAttack": 65, "specialDefense": 110, "speed": 30 },
+    "types": ["normal"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/143.png"
+  },
+  "dratini": {
+    "id": 147, "name": "dratini",
+    "stats": { "hp": 41, "attack": 64, "defense": 45, "specialAttack": 50, "specialDefense": 50, "speed": 50 },
+    "types": ["dragon"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/147.png"
+  },
+  "dragonair": {
+    "id": 148, "name": "dragonair",
+    "stats": { "hp": 61, "attack": 84, "defense": 65, "specialAttack": 70, "specialDefense": 70, "speed": 70 },
+    "types": ["dragon"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/148.png"
+  },
+  "dragonite": {
+    "id": 149, "name": "dragonite",
+    "stats": { "hp": 91, "attack": 134, "defense": 95, "specialAttack": 100, "specialDefense": 100, "speed": 80 },
+    "types": ["dragon", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/149.png"
+  },
+  "mewtwo": {
+    "id": 150, "name": "mewtwo",
+    "stats": { "hp": 106, "attack": 110, "defense": 90, "specialAttack": 154, "specialDefense": 90, "speed": 130 },
+    "types": ["psychic"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/150.png"
+  },
+  "mew": {
+    "id": 151, "name": "mew",
+    "stats": { "hp": 100, "attack": 100, "defense": 100, "specialAttack": 100, "specialDefense": 100, "speed": 100 },
+    "types": ["psychic"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/151.png"
+  },
+  "chikorita": {
+    "id": 152, "name": "chikorita",
+    "stats": { "hp": 45, "attack": 49, "defense": 65, "specialAttack": 49, "specialDefense": 65, "speed": 45 },
+    "types": ["grass"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/152.png"
+  },
+  "bayleef": {
+    "id": 153, "name": "bayleef",
+    "stats": { "hp": 60, "attack": 62, "defense": 80, "specialAttack": 63, "specialDefense": 80, "speed": 60 },
+    "types": ["grass"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/153.png"
+  },
+  "meganium": {
+    "id": 154, "name": "meganium",
+    "stats": { "hp": 80, "attack": 82, "defense": 100, "specialAttack": 83, "specialDefense": 100, "speed": 80 },
+    "types": ["grass"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/154.png"
+  },
+  "cyndaquil": {
+    "id": 155, "name": "cyndaquil",
+    "stats": { "hp": 39, "attack": 52, "defense": 43, "specialAttack": 60, "specialDefense": 50, "speed": 65 },
+    "types": ["fire"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/155.png"
+  },
+  "quilava": {
+    "id": 156, "name": "quilava",
+    "stats": { "hp": 58, "attack": 64, "defense": 58, "specialAttack": 80, "specialDefense": 65, "speed": 80 },
+    "types": ["fire"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/156.png"
+  },
+  "typhlosion": {
+    "id": 157, "name": "typhlosion",
+    "stats": { "hp": 78, "attack": 84, "defense": 78, "specialAttack": 109, "specialDefense": 85, "speed": 100 },
+    "types": ["fire"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/157.png"
+  },
+  "totodile": {
+    "id": 158, "name": "totodile",
+    "stats": { "hp": 50, "attack": 65, "defense": 64, "specialAttack": 44, "specialDefense": 48, "speed": 43 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/158.png"
+  },
+  "croconaw": {
+    "id": 159, "name": "croconaw",
+    "stats": { "hp": 65, "attack": 80, "defense": 80, "specialAttack": 59, "specialDefense": 63, "speed": 58 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/159.png"
+  },
+  "feraligatr": {
+    "id": 160, "name": "feraligatr",
+    "stats": { "hp": 85, "attack": 105, "defense": 100, "specialAttack": 79, "specialDefense": 83, "speed": 78 },
+    "types": ["water"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/160.png"
+  },
+  "togepi": {
+    "id": 175, "name": "togepi",
+    "stats": { "hp": 35, "attack": 20, "defense": 65, "specialAttack": 40, "specialDefense": 65, "speed": 20 },
+    "types": ["fairy"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/175.png"
+  },
+  "togetic": {
+    "id": 176, "name": "togetic",
+    "stats": { "hp": 55, "attack": 40, "defense": 85, "specialAttack": 80, "specialDefense": 105, "speed": 40 },
+    "types": ["fairy", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/176.png"
+  },
+   "mareep": {
+    "id": 179, "name": "mareep",
+    "stats": { "hp": 55, "attack": 40, "defense": 40, "specialAttack": 65, "specialDefense": 45, "speed": 35 },
+    "types": ["electric"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/179.png"
+  },
+  "flaaffy": {
+    "id": 180, "name": "flaaffy",
+    "stats": { "hp": 70, "attack": 55, "defense": 55, "specialAttack": 80, "specialDefense": 60, "speed": 45 },
+    "types": ["electric"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/180.png"
+  },
+  "ampharos": {
+    "id": 181, "name": "ampharos",
+    "stats": { "hp": 90, "attack": 75, "defense": 85, "specialAttack": 115, "specialDefense": 90, "speed": 55 },
+    "types": ["electric"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/181.png"
+  },
+  "espeon": {
+    "id": 196, "name": "espeon",
+    "stats": { "hp": 65, "attack": 65, "defense": 60, "specialAttack": 130, "specialDefense": 95, "speed": 110 },
+    "types": ["psychic"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/196.png"
+  },
+  "umbreon": {
+    "id": 197, "name": "umbreon",
+    "stats": { "hp": 95, "attack": 65, "defense": 110, "specialAttack": 60, "specialDefense": 130, "speed": 65 },
+    "types": ["dark"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/197.png"
+  },
+  "scizor": {
+    "id": 212, "name": "scizor",
+    "stats": { "hp": 70, "attack": 130, "defense": 100, "specialAttack": 55, "specialDefense": 80, "speed": 65 },
+    "types": ["bug", "steel"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/212.png"
+  },
+  "heracross": {
+    "id": 214, "name": "heracross",
+    "stats": { "hp": 80, "attack": 125, "defense": 75, "specialAttack": 40, "specialDefense": 95, "speed": 85 },
+    "types": ["bug", "fighting"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/214.png"
+  },
+  "larvitar": {
+    "id": 246, "name": "larvitar",
+    "stats": { "hp": 50, "attack": 64, "defense": 50, "specialAttack": 45, "specialDefense": 50, "speed": 41 },
+    "types": ["rock", "ground"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/246.png"
+  },
+  "pupitar": {
+    "id": 247, "name": "pupitar",
+    "stats": { "hp": 70, "attack": 84, "defense": 70, "specialAttack": 65, "specialDefense": 70, "speed": 51 },
+    "types": ["rock", "ground"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/247.png"
+  },
+  "tyranitar": {
+    "id": 248, "name": "tyranitar",
+    "stats": { "hp": 100, "attack": 134, "defense": 110, "specialAttack": 95, "specialDefense": 100, "speed": 61 },
+    "types": ["rock", "dark"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/248.png"
+  },
+   "lugia": {
+    "id": 249, "name": "lugia",
+    "stats": { "hp": 106, "attack": 90, "defense": 130, "specialAttack": 90, "specialDefense": 154, "speed": 110 },
+    "types": ["psychic", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/249.png"
+  },
+  "ho-oh": {
+    "id": 250, "name": "ho-oh",
+    "stats": { "hp": 106, "attack": 130, "defense": 90, "specialAttack": 110, "specialDefense": 154, "speed": 90 },
+    "types": ["fire", "flying"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/250.png"
+  },
+  "celebi": {
+    "id": 251, "name": "celebi",
+    "stats": { "hp": 100, "attack": 100, "defense": 100, "specialAttack": 100, "specialDefense": 100, "speed": 100 },
+    "types": ["psychic", "grass"], "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/251.png"
+  }
 };
 
-// Function to get a deep copy of Pokemon details to avoid mutation of the base data
-const getPokemonDetails = (pokemonName) => {
-    if (POKEMON_DATA[pokemonName]) {
-        return JSON.parse(JSON.stringify(POKEMON_DATA[pokemonName]));
+// Helper function to get a deep copy of Pokemon details by name
+// Ensures case-insensitivity for pokemonName lookup
+function getPokemonDetails(pokemonName) {
+    if (!pokemonName || typeof pokemonName !== 'string') {
+        return null;
+    }
+    // Find the key in POKEMON_DATA that matches pokemonName case-insensitively
+    const foundKey = Object.keys(POKEMON_DATA).find(key => key.toLowerCase() === pokemonName.toLowerCase());
+
+    if (foundKey && POKEMON_DATA[foundKey]) {
+        return JSON.parse(JSON.stringify(POKEMON_DATA[foundKey]));
     }
     return null;
-};
+}
 
-module.exports = {
-    POKEMON_DATA,
-    getPokemonDetails
-};
+module.exports = { POKEMON_DATA, getPokemonDetails };

--- a/pokemon-battle-backend/scripts/fetchPokemonData.js
+++ b/pokemon-battle-backend/scripts/fetchPokemonData.js
@@ -1,0 +1,184 @@
+// pokemon-battle-backend/scripts/fetchPokemonData.js
+const axios = require('axios');
+const fs = require('fs');
+const path = require('path');
+
+const POKEAPI_BASE_URL = 'https://pokeapi.co/api/v2';
+const OUTPUT_FILE_PATH = path.join(__dirname, '..', 'pokemonDataGenerated.js');
+const START_ID = 1;
+const END_ID = 151; // Fetching Gen 1 only to reduce script runtime & complexity for now
+
+// Helper to get stat value
+const getStat = (stats, statName) => {
+    const foundStat = stats.find(s => s.stat.name === statName);
+    return foundStat ? foundStat.base_stat : 0;
+};
+
+// Helper to check if a Pokemon is a final evolution
+async function isFinalEvolution(speciesUrl, pokemonNameToCheck) {
+    try {
+        const speciesResponse = await axios.get(speciesUrl);
+        const evolutionChainUrl = speciesResponse.data.evolution_chain.url;
+        const evolutionChainResponse = await axios.get(evolutionChainUrl);
+
+        let currentEvolution = evolutionChainResponse.data.chain;
+
+        // Function to find the specific pokemon in the chain and check if it's a terminal node
+        function checkChain(chain) {
+            if (chain.species.name === pokemonNameToCheck) {
+                return chain.evolves_to.length === 0; // It's final if it evolves to nothing
+            }
+            // If not this one, check its evolutions
+            for (const evo of chain.evolves_to) {
+                if (checkChain(evo)) { // If any path starting from here leads to it being final
+                    return true;
+                }
+            }
+            return false; // Not found in this path or not final in this path
+        }
+
+        // Simplified: We are checking if the Pokemon *itself* is a final stage.
+        // The API structure means we need to find our specific Pokemon in the possibly branching chain.
+        let queue = [evolutionChainResponse.data.chain];
+        while(queue.length > 0) {
+            let currentLink = queue.shift();
+            if (currentLink.species.name === pokemonNameToCheck) {
+                return currentLink.evolves_to.length === 0;
+            }
+            currentLink.evolves_to.forEach(evo => queue.push(evo));
+        }
+        // If the specific Pokemon is not found in the main chain (e.g. some baby Pokemon might be listed under their own species evolution)
+        // or if it's a Pokemon that doesn't evolve at all.
+        if (speciesResponse.data.evolves_from_species === null && speciesResponse.data.evolution_chain.url) {
+             // It doesn't evolve from anything, check if it has evolutions
+             // This check is essentially covered by the chain traversal for the named pokemon.
+        }
+        // Fallback if not found explicitly in the chain by name (shouldn't happen for valid Pokemon)
+        // or for Pokemon that don't evolve at all (their chain.evolves_to will be empty).
+        // The problem is complex for branched evolutions if we are not careful.
+        // The check above (finding the pokemon by name in the chain and checking its evolves_to) is more direct.
+        return false; // Default to not final if complex branching makes it hard or not found by name in chain.
+
+    } catch (error) {
+        console.error(`Error checking evolution chain for ${pokemonNameToCheck} (${speciesUrl}):`, error.message);
+        return false; // Assume not final if error occurs
+    }
+}
+
+async function fetchAllPokemonData() {
+    const allPokemonData = {};
+    console.log(`Fetching Pokemon data from ID ${START_ID} to ${END_ID}...`);
+
+    for (let id = START_ID; id <= END_ID; id++) {
+        try {
+            console.log(`Fetching Pokemon ID: ${id}`);
+            const response = await axios.get(`${POKEAPI_BASE_URL}/pokemon/${id}`);
+            const pokemon = response.data;
+            const pokemonName = pokemon.name;
+
+            // Check if it's a "final evolution" (or a Pokemon that doesn't evolve)
+            // This is a simplified check; true evolution chains can be complex.
+            // We will fetch the species data and check if 'evolves_to' is empty for this specific Pokemon.
+            const speciesResponse = await axios.get(pokemon.species.url);
+            const evolutionChainUrl = speciesResponse.data.evolution_chain.url;
+            const evolutionChainResponse = await axios.get(evolutionChainUrl);
+            let chain = evolutionChainResponse.data.chain;
+
+            let isThisPokemonFinalInItsBranch = false;
+            const findAndCheckIfFinal = (node, name) => {
+                if (node.species.name === name) {
+                    if (node.evolves_to.length === 0) {
+                        isThisPokemonFinalInItsBranch = true;
+                    }
+                    return true; // Found it
+                }
+                for (const evo of node.evolves_to) {
+                    if (findAndCheckIfFinal(evo, name)) return true;
+                }
+                return false;
+            };
+
+            findAndCheckIfFinal(chain, pokemonName);
+
+
+            if (!isThisPokemonFinalInItsBranch) {
+                 // Additional check for Pokemon that don't evolve at all (e.g. Pinsir, Tauros)
+                 // Such Pokemon might not have an 'evolves_to' in the main chain structure for *them*,
+                 // but their species data indicates no further evolution.
+                 if (speciesResponse.data.evolves_from_species === null && chain.species.name === pokemonName && chain.evolves_to.length === 0) {
+                     console.log(`${pokemonName} (ID: ${id}) does not evolve. Processing...`);
+                 } else if (speciesResponse.data.evolves_from_species !== null && !isThisPokemonFinalInItsBranch) { // only skip if it evolves from something AND is not final in its branch
+                    console.log(`Skipping ${pokemonName} (ID: ${id}) - not a final evolution in its branch.`);
+                    await new Promise(resolve => setTimeout(resolve, 50)); // Small delay
+                    continue;
+                 } else if (speciesResponse.data.evolves_from_species === null && !isThisPokemonFinalInItsBranch && chain.species.name !== pokemonName) {
+                    // This case implies it's a base form of a branching evolution that itself evolves, skip.
+                    // Or it's a Pokemon that doesn't evolve but wasn't the start of the chain.
+                    console.log(`Skipping ${pokemonName} (ID: ${id}) - complex case or not final.`);
+                    await new Promise(resolve => setTimeout(resolve, 50));
+                    continue;
+                 }
+                 // If it doesn't evolve from anything, AND it was found and its evolves_to is empty, it's already true.
+                 // If it doesn't evolve from anything, and it IS the start of the chain, but has evolutions, it's not final.
+                 // This is tricky. The `isThisPokemonFinalInItsBranch` should ideally be the main flag.
+            }
+
+            console.log(`${pokemonName} (ID: ${id}) is considered final or non-evolving. Processing...`);
+
+            const types = pokemon.types.map(typeInfo => typeInfo.type.name);
+            const sprite = pokemon.sprites.other['official-artwork']?.front_default || pokemon.sprites.front_default || pokemon.sprites.versions?.['generation-v']?.['black-white']?.animated?.front_default || '';
+
+
+            allPokemonData[pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1)] = { // Capitalize first letter of name
+                id: pokemon.id,
+                name: pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1),
+                stats: {
+                    hp: getStat(pokemon.stats, 'hp'),
+                    attack: getStat(pokemon.stats, 'attack'),
+                    defense: getStat(pokemon.stats, 'defense'),
+                    specialAttack: getStat(pokemon.stats, 'special-attack'), // API uses 'special-attack'
+                    specialDefense: getStat(pokemon.stats, 'special-defense'), // API uses 'special-defense'
+                    speed: getStat(pokemon.stats, 'speed'),
+                },
+                types: types,
+                sprite: sprite,
+            };
+            await new Promise(resolve => setTimeout(resolve, 150)); // Increased delay
+        } catch (error) {
+            console.error(`Failed to fetch data for Pokemon ID ${id}:`, error.message);
+            if (error.response?.status === 404) {
+                console.log(`Pokemon ID ${id} not found, skipping.`);
+            }
+            await new Promise(resolve => setTimeout(resolve, 150)); // Delay even on error
+        }
+    }
+
+    console.log(`\nFetched data for ${Object.keys(allPokemonData).length} Pokemon.`);
+
+    const outputContent = \`// Generated on ${new Date().toISOString()}
+// Fetched IDs: ${START_ID}-${END_ID}
+// Only includes Pokemon considered final evolutions or those that don't evolve.
+
+const POKEMON_DATA = ${JSON.stringify(allPokemonData, null, 2)};
+
+// Helper function to get a deep copy of Pokemon details by name
+function getPokemonDetails(pokemonName) {
+    const normalizedName = Object.keys(POKEMON_DATA).find(key => key.toLowerCase() === pokemonName.toLowerCase());
+    if (POKEMON_DATA[normalizedName]) {
+        return JSON.parse(JSON.stringify(POKEMON_DATA[normalizedName]));
+    }
+    return null;
+}
+
+module.exports = { POKEMON_DATA, getPokemonDetails };
+\`;
+
+    try {
+        fs.writeFileSync(OUTPUT_FILE_PATH, outputContent);
+        console.log(\`Pokemon data successfully written to ${OUTPUT_FILE_PATH}\`);
+    } catch (error) {
+        console.error(\`Error writing to file ${OUTPUT_FILE_PATH}:\`, error.message);
+    }
+}
+
+fetchAllPokemonData();

--- a/pokemon-battle/src/components/PokemonSelection.jsx
+++ b/pokemon-battle/src/components/PokemonSelection.jsx
@@ -1,20 +1,188 @@
 import React, { useState, useEffect } from 'react';
 import './PokemonSelection.css'; // Import the new CSS
 
-const AVAILABLE_POKEMON = [
-  { id: 1, name: 'Bulbasaur', type: 'Grass/Poison', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/1.png' },
-  { id: 4, name: 'Charmander', type: 'Fire', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/4.png' },
-  { id: 7, name: 'Squirtle', type: 'Water', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/7.png' },
-  { id: 25, name: 'Pikachu', type: 'Electric', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/25.png' },
-  { id: 39, name: 'Jigglypuff', type: 'Normal/Fairy', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/39.png' },
-  { id: 52, name: 'Meowth', type: 'Normal', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/52.png' },
-  { id: 66, name: 'Machop', type: 'Fighting', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/66.png' },
-  { id: 74, name: 'Geodude', type: 'Rock/Ground', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/74.png' },
-  { id: 92, name: 'Gastly', type: 'Ghost/Poison', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/92.png' },
-  { id: 133, name: 'Eevee', type: 'Normal', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/133.png' },
-  { id: 143, name: 'Snorlax', type: 'Normal', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/143.png' },
-  { id: 150, name: 'Mewtwo', type: 'Psychic', sprite: 'https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/150.png' },
-];
+// New, expanded Pokemon data (mirrors backend structure for consistency)
+const POKEMON_DATA_FRONTEND = {
+  "bulbasaur": {
+    "id": 1, "name": "bulbasaur", "types": ["grass", "poison"], "stats": { "hp": 45, "attack": 49, "defense": 49, "specialAttack": 65, "specialDefense": 65, "speed": 45 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/1.png"
+  },
+  "ivysaur": {
+    "id": 2, "name": "ivysaur", "types": ["grass", "poison"], "stats": { "hp": 60, "attack": 62, "defense": 63, "specialAttack": 80, "specialDefense": 80, "speed": 60 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/2.png"
+  },
+  "venusaur": {
+    "id": 3, "name": "venusaur", "types": ["grass", "poison"], "stats": { "hp": 80, "attack": 82, "defense": 83, "specialAttack": 100, "specialDefense": 100, "speed": 80 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/3.png"
+  },
+  "charmander": {
+    "id": 4, "name": "charmander", "types": ["fire"], "stats": { "hp": 39, "attack": 52, "defense": 43, "specialAttack": 60, "specialDefense": 50, "speed": 65 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/4.png"
+  },
+  "charmeleon": {
+    "id": 5, "name": "charmeleon", "types": ["fire"], "stats": { "hp": 58, "attack": 64, "defense": 58, "specialAttack": 80, "specialDefense": 65, "speed": 80 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/5.png"
+  },
+  "charizard": {
+    "id": 6, "name": "charizard", "types": ["fire", "flying"], "stats": { "hp": 78, "attack": 84, "defense": 78, "specialAttack": 109, "specialDefense": 85, "speed": 100 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/6.png"
+  },
+  "squirtle": {
+    "id": 7, "name": "squirtle", "types": ["water"], "stats": { "hp": 44, "attack": 48, "defense": 65, "specialAttack": 50, "specialDefense": 64, "speed": 43 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/7.png"
+  },
+  "wartortle": {
+    "id": 8, "name": "wartortle", "types": ["water"], "stats": { "hp": 59, "attack": 63, "defense": 80, "specialAttack": 65, "specialDefense": 80, "speed": 58 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/8.png"
+  },
+  "blastoise": {
+    "id": 9, "name": "blastoise", "types": ["water"], "stats": { "hp": 79, "attack": 83, "defense": 100, "specialAttack": 85, "specialDefense": 105, "speed": 78 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/9.png"
+  },
+  "caterpie": {
+    "id": 10, "name": "caterpie", "types": ["bug"], "stats": { "hp": 45, "attack": 30, "defense": 35, "specialAttack": 20, "specialDefense": 20, "speed": 45 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/10.png"
+  },
+  "metapod": {
+    "id": 11, "name": "metapod", "types": ["bug"], "stats": { "hp": 50, "attack": 20, "defense": 55, "specialAttack": 25, "specialDefense": 25, "speed": 30 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/11.png"
+  },
+  "butterfree": {
+    "id": 12, "name": "butterfree", "types": ["bug", "flying"], "stats": { "hp": 60, "attack": 45, "defense": 50, "specialAttack": 90, "specialDefense": 80, "speed": 70 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/12.png"
+  },
+  "pidgey": {
+    "id": 16, "name": "pidgey", "types": ["normal", "flying"], "stats": { "hp": 40, "attack": 45, "defense": 40, "specialAttack": 35, "specialDefense": 35, "speed": 56 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/16.png"
+  },
+  "pidgeotto": {
+    "id": 17, "name": "pidgeotto", "types": ["normal", "flying"], "stats": { "hp": 63, "attack": 60, "defense": 55, "specialAttack": 50, "specialDefense": 50, "speed": 71 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/17.png"
+  },
+  "pidgeot": {
+    "id": 18, "name": "pidgeot", "types": ["normal", "flying"], "stats": { "hp": 83, "attack": 80, "defense": 75, "specialAttack": 70, "specialDefense": 70, "speed": 101 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/18.png"
+  },
+  "pikachu": {
+    "id": 25, "name": "pikachu", "types": ["electric"], "stats": { "hp": 35, "attack": 55, "defense": 40, "specialAttack": 50, "specialDefense": 50, "speed": 90 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/25.png"
+  },
+  "raichu": {
+    "id": 26, "name": "raichu", "types": ["electric"], "stats": { "hp": 60, "attack": 90, "defense": 55, "specialAttack": 90, "specialDefense": 80, "speed": 110 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/26.png"
+  },
+  "jigglypuff": {
+    "id": 39, "name": "jigglypuff", "types": ["normal", "fairy"], "stats": { "hp": 115, "attack": 45, "defense": 20, "specialAttack": 45, "specialDefense": 25, "speed": 20 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/39.png"
+  },
+  "wigglytuff": {
+    "id": 40, "name": "wigglytuff", "types": ["normal", "fairy"], "stats": { "hp": 140, "attack": 70, "defense": 45, "specialAttack": 85, "specialDefense": 50, "speed": 45 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/40.png"
+  },
+  "abra": {
+    "id": 63, "name": "abra", "types": ["psychic"], "stats": { "hp": 25, "attack": 20, "defense": 15, "specialAttack": 105, "specialDefense": 55, "speed": 90 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/63.png"
+  },
+  "kadabra": {
+    "id": 64, "name": "kadabra", "types": ["psychic"], "stats": { "hp": 40, "attack": 35, "defense": 30, "specialAttack": 120, "specialDefense": 70, "speed": 105 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/64.png"
+  },
+  "alakazam": {
+    "id": 65, "name": "alakazam", "types": ["psychic"], "stats": { "hp": 55, "attack": 50, "defense": 45, "specialAttack": 135, "specialDefense": 95, "speed": 120 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/65.png"
+  },
+  "gastly": {
+    "id": 92, "name": "gastly", "types": ["ghost", "poison"], "stats": { "hp": 30, "attack": 35, "defense": 30, "specialAttack": 100, "specialDefense": 35, "speed": 80 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/92.png"
+  },
+  "haunter": {
+    "id": 93, "name": "haunter", "types": ["ghost", "poison"], "stats": { "hp": 45, "attack": 50, "defense": 45, "specialAttack": 115, "specialDefense": 55, "speed": 95 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/93.png"
+  },
+  "gengar": {
+    "id": 94, "name": "gengar", "types": ["ghost", "poison"], "stats": { "hp": 60, "attack": 65, "defense": 60, "specialAttack": 130, "specialDefense": 75, "speed": 110 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/94.png"
+  },
+  "eevee": {
+    "id": 133, "name": "eevee", "types": ["normal"], "stats": { "hp": 55, "attack": 55, "defense": 50, "specialAttack": 45, "specialDefense": 65, "speed": 55 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/133.png"
+  },
+  "vaporeon": {
+    "id": 134, "name": "vaporeon", "types": ["water"], "stats": { "hp": 130, "attack": 65, "defense": 60, "specialAttack": 110, "specialDefense": 95, "speed": 65 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/134.png"
+  },
+  "jolteon": {
+    "id": 135, "name": "jolteon", "types": ["electric"], "stats": { "hp": 65, "attack": 65, "defense": 60, "specialAttack": 110, "specialDefense": 95, "speed": 130 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/135.png"
+  },
+  "flareon": {
+    "id": 136, "name": "flareon", "types": ["fire"], "stats": { "hp": 65, "attack": 130, "defense": 60, "specialAttack": 95, "specialDefense": 110, "speed": 65 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/136.png"
+  },
+  "snorlax": {
+    "id": 143, "name": "snorlax", "types": ["normal"], "stats": { "hp": 160, "attack": 110, "defense": 65, "specialAttack": 65, "specialDefense": 110, "speed": 30 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/143.png"
+  },
+  "dratini": {
+    "id": 147, "name": "dratini", "types": ["dragon"], "stats": { "hp": 41, "attack": 64, "defense": 45, "specialAttack": 50, "specialDefense": 50, "speed": 50 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/147.png"
+  },
+  "dragonair": {
+    "id": 148, "name": "dragonair", "types": ["dragon"], "stats": { "hp": 61, "attack": 84, "defense": 65, "specialAttack": 70, "specialDefense": 70, "speed": 70 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/148.png"
+  },
+  "dragonite": {
+    "id": 149, "name": "dragonite", "types": ["dragon", "flying"], "stats": { "hp": 91, "attack": 134, "defense": 95, "specialAttack": 100, "specialDefense": 100, "speed": 80 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/149.png"
+  },
+  "mewtwo": {
+    "id": 150, "name": "mewtwo", "types": ["psychic"], "stats": { "hp": 106, "attack": 110, "defense": 90, "specialAttack": 154, "specialDefense": 90, "speed": 130 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/150.png"
+  },
+  "mew": {
+    "id": 151, "name": "mew", "types": ["psychic"], "stats": { "hp": 100, "attack": 100, "defense": 100, "specialAttack": 100, "specialDefense": 100, "speed": 100 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/151.png"
+  },
+  "chikorita": {
+    "id": 152, "name": "chikorita", "types": ["grass"], "stats": { "hp": 45, "attack": 49, "defense": 65, "specialAttack": 49, "specialDefense": 65, "speed": 45 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/152.png"
+  },
+  "bayleef": {
+    "id": 153, "name": "bayleef", "types": ["grass"], "stats": { "hp": 60, "attack": 62, "defense": 80, "specialAttack": 63, "specialDefense": 80, "speed": 60 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/153.png"
+  },
+  "meganium": {
+    "id": 154, "name": "meganium", "types": ["grass"], "stats": { "hp": 80, "attack": 82, "defense": 100, "specialAttack": 83, "specialDefense": 100, "speed": 80 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/154.png"
+  },
+  "cyndaquil": {
+    "id": 155, "name": "cyndaquil", "types": ["fire"], "stats": { "hp": 39, "attack": 52, "defense": 43, "specialAttack": 60, "specialDefense": 50, "speed": 65 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/155.png"
+  },
+  "quilava": {
+    "id": 156, "name": "quilava", "types": ["fire"], "stats": { "hp": 58, "attack": 64, "defense": 58, "specialAttack": 80, "specialDefense": 65, "speed": 80 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/156.png"
+  },
+  "typhlosion": {
+    "id": 157, "name": "typhlosion", "types": ["fire"], "stats": { "hp": 78, "attack": 84, "defense": 78, "specialAttack": 109, "specialDefense": 85, "speed": 100 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/157.png"
+  },
+  "totodile": {
+    "id": 158, "name": "totodile", "types": ["water"], "stats": { "hp": 50, "attack": 65, "defense": 64, "specialAttack": 44, "specialDefense": 48, "speed": 43 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/158.png"
+  },
+  "croconaw": {
+    "id": 159, "name": "croconaw", "types": ["water"], "stats": { "hp": 65, "attack": 80, "defense": 80, "specialAttack": 59, "specialDefense": 63, "speed": 58 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/159.png"
+  },
+  "feraligatr": {
+    "id": 160, "name": "feraligatr", "types": ["water"], "stats": { "hp": 85, "attack": 105, "defense": 100, "specialAttack": 79, "specialDefense": 83, "speed": 78 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/160.png"
+  },
+  "togepi": {
+    "id": 175, "name": "togepi", "types": ["fairy"], "stats": { "hp": 35, "attack": 20, "defense": 65, "specialAttack": 40, "specialDefense": 65, "speed": 20 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/175.png"
+  },
+  "togetic": {
+    "id": 176, "name": "togetic", "types": ["fairy", "flying"], "stats": { "hp": 55, "attack": 40, "defense": 85, "specialAttack": 80, "specialDefense": 105, "speed": 40 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/176.png"
+  },
+   "mareep": {
+    "id": 179, "name": "mareep", "types": ["electric"], "stats": { "hp": 55, "attack": 40, "defense": 40, "specialAttack": 65, "specialDefense": 45, "speed": 35 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/179.png"
+  },
+  "flaaffy": {
+    "id": 180, "name": "flaaffy", "types": ["electric"], "stats": { "hp": 70, "attack": 55, "defense": 55, "specialAttack": 80, "specialDefense": 60, "speed": 45 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/180.png"
+  },
+  "ampharos": {
+    "id": 181, "name": "ampharos", "types": ["electric"], "stats": { "hp": 90, "attack": 75, "defense": 85, "specialAttack": 115, "specialDefense": 90, "speed": 55 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/181.png"
+  },
+  "espeon": {
+    "id": 196, "name": "espeon", "types": ["psychic"], "stats": { "hp": 65, "attack": 65, "defense": 60, "specialAttack": 130, "specialDefense": 95, "speed": 110 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/196.png"
+  },
+  "umbreon": {
+    "id": 197, "name": "umbreon", "types": ["dark"], "stats": { "hp": 95, "attack": 65, "defense": 110, "specialAttack": 60, "specialDefense": 130, "speed": 65 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/197.png"
+  },
+  "scizor": {
+    "id": 212, "name": "scizor", "types": ["bug", "steel"], "stats": { "hp": 70, "attack": 130, "defense": 100, "specialAttack": 55, "specialDefense": 80, "speed": 65 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/212.png"
+  },
+  "heracross": {
+    "id": 214, "name": "heracross", "types": ["bug", "fighting"], "stats": { "hp": 80, "attack": 125, "defense": 75, "specialAttack": 40, "specialDefense": 95, "speed": 85 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/214.png"
+  },
+  "larvitar": {
+    "id": 246, "name": "larvitar", "types": ["rock", "ground"], "stats": { "hp": 50, "attack": 64, "defense": 50, "specialAttack": 45, "specialDefense": 50, "speed": 41 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/246.png"
+  },
+  "pupitar": {
+    "id": 247, "name": "pupitar", "types": ["rock", "ground"], "stats": { "hp": 70, "attack": 84, "defense": 70, "specialAttack": 65, "specialDefense": 70, "speed": 51 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/247.png"
+  },
+  "tyranitar": {
+    "id": 248, "name": "tyranitar", "types": ["rock", "dark"], "stats": { "hp": 100, "attack": 134, "defense": 110, "specialAttack": 95, "specialDefense": 100, "speed": 61 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/248.png"
+  },
+   "lugia": {
+    "id": 249, "name": "lugia", "types": ["psychic", "flying"], "stats": { "hp": 106, "attack": 90, "defense": 130, "specialAttack": 90, "specialDefense": 154, "speed": 110 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/249.png"
+  },
+  "ho-oh": {
+    "id": 250, "name": "ho-oh", "types": ["fire", "flying"], "stats": { "hp": 106, "attack": 130, "defense": 90, "specialAttack": 110, "specialDefense": 154, "speed": 90 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/250.png"
+  },
+  "celebi": {
+    "id": 251, "name": "celebi", "types": ["psychic", "grass"], "stats": { "hp": 100, "attack": 100, "defense": 100, "specialAttack": 100, "specialDefense": 100, "speed": 100 }, "sprite": "https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/other/official-artwork/251.png"
+  }
+};
+
+const AVAILABLE_POKEMON = Object.values(POKEMON_DATA_FRONTEND).sort((a, b) => a.id - b.id);
 
 const DEFAULT_MAX_TEAM_SIZE = 6;
 
@@ -22,7 +190,7 @@ function PokemonSelection({ onTeamConfirmed, playerId, gameData, isLoading: prop
   const [selectedTeam, setSelectedTeam] = useState([]);
   const [error, setError] = useState('');
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [searchTerm, setSearchTerm] = useState(''); // State for search term
+  const [searchTerm, setSearchTerm] = useState('');
 
   const gameMaxTeamSize = gameData?.maxTeamSize || DEFAULT_MAX_TEAM_SIZE;
   const currentPlayerInGame = gameData?.players?.find(p => p.id === playerId);
@@ -31,13 +199,17 @@ function PokemonSelection({ onTeamConfirmed, playerId, gameData, isLoading: prop
   useEffect(() => {
     if (hasPlayerConfirmedPartyBackend && currentPlayerInGame.party) {
         const confirmedPartyDetails = currentPlayerInGame.party.map(p_backend => {
-            return AVAILABLE_POKEMON.find(ap => ap.name === p_backend.details.name) || p_backend.details;
+            // Use the name from backend's details, ensure it's lowercase for lookup in POKEMON_DATA_FRONTEND
+            const backendNameLower = p_backend.details.name.toLowerCase();
+            return POKEMON_DATA_FRONTEND[backendNameLower] || p_backend.details; // Fallback if not in frontend's list
         });
         setSelectedTeam(confirmedPartyDetails);
     } else if (!hasPlayerConfirmedPartyBackend) {
         setSelectedTeam([]);
     }
+  // Ensure POKEMON_DATA_FRONTEND is stable or memoized if it were dynamic, not an issue here as it's a const.
   }, [hasPlayerConfirmedPartyBackend, currentPlayerInGame]);
+
 
   const handleSelectPokemon = (pokemon) => {
     if (hasPlayerConfirmedPartyBackend) return;
@@ -67,7 +239,7 @@ function PokemonSelection({ onTeamConfirmed, playerId, gameData, isLoading: prop
         setError("You have already confirmed your team.");
         return;
     }
-    const teamToConfirmNames = selectedTeam.map(p => p.name);
+    const teamToConfirmNames = selectedTeam.map(p => p.name); // Backend expects lowercase names
     setIsSubmitting(true);
     setError('');
     try {
@@ -104,7 +276,7 @@ function PokemonSelection({ onTeamConfirmed, playerId, gameData, isLoading: prop
                 {currentPlayerInGame.party.map((p, index) => (
                     <li key={p.details.id || index} className="confirmed-party-item">
                     <img src={p.details.sprite} alt={p.details.name} />
-                    <p>{p.details.name}</p>
+                    <p>{p.details.name.charAt(0).toUpperCase() + p.details.name.slice(1)}</p> {/* Capitalize for display */}
                     </li>
                 ))}
                 </ul>
@@ -125,22 +297,25 @@ function PokemonSelection({ onTeamConfirmed, playerId, gameData, isLoading: prop
                 {filteredPokemonList.map(pokemon => {
                   const isSelected = selectedTeam.find(p => p.id === pokemon.id);
                   const isMaxReached = selectedTeam.length >= gameMaxTeamSize;
+                  // Disable click if backend confirmed, or if max reached and this one isn't selected
                   const isDisabled = hasPlayerConfirmedPartyBackend || (isMaxReached && !isSelected);
 
                   let cardClass = "pokemon-card-select";
                   if (isSelected) cardClass += " selected";
-                  if (isDisabled && !isSelected) cardClass += " disabled";
-                  if (isMaxReached && !isSelected && !hasPlayerConfirmedPartyBackend) cardClass += " max-reached";
+                  if (isDisabled && !isSelected && !hasPlayerConfirmedPartyBackend) cardClass += " disabled"; // Dim if max reached and not selectable
+                  else if (isDisabled && !isSelected && hasPlayerConfirmedPartyBackend) cardClass += " disabled";
+
 
                   return (
                     <div
                       key={pokemon.id}
                       className={cardClass}
                       onClick={() => !isDisabled && handleSelectPokemon(pokemon)}
+                      title={pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1)} // Tooltip with name
                     >
                       <img src={pokemon.sprite} alt={pokemon.name} />
-                      <p className="name">{pokemon.name}</p>
-                      <p className="type">{pokemon.type}</p>
+                      <p className="name">{pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1)}</p> {/* Capitalize for display */}
+                      <p className="type">{pokemon.types.join(' / ')}</p>
                     </div>
                   );
                 })}
@@ -160,7 +335,7 @@ function PokemonSelection({ onTeamConfirmed, playerId, gameData, isLoading: prop
                       {pokemon ? (
                         <>
                           <img src={pokemon.sprite} alt={pokemon.name} />
-                          <p className="name">{pokemon.name}</p>
+                          <p className="name">{pokemon.name.charAt(0).toUpperCase() + pokemon.name.slice(1)}</p> {/* Capitalize */}
                         </>
                       ) : (
                         <p className="empty-text">Slot {i+1}</p>


### PR DESCRIPTION
This commit expands the available Pokemon dataset used in the game.

Backend (`pokemon-battle-backend`):
- `pokemonData.js` has been updated with a manually curated, expanded list of Pokemon (approx. 50-70, focusing on Gen 1 & 2, including various evolution lines and popular Pokemon). This replaces the previous smaller placeholder dataset.
- Each Pokemon entry includes ID, name (lowercase), detailed stats, types, and an official artwork sprite URL.
- The `getPokemonDetails(pokemonName)` function in `pokemonData.js` has been made case-insensitive for more robust lookups.

Frontend (`pokemon-battle`):
- `PokemonSelection.jsx` now sources its `AVAILABLE_POKEMON` list from a data structure (`POKEMON_DATA_FRONTEND`) that mirrors the expanded backend `pokemonData.js`.
- Pokemon names are capitalized for display in the selection list and team view, while internal logic uses lowercase names consistent with the backend.

This provides you with a significantly larger and more diverse pool of Pokemon to choose from, enhancing the team-building aspect of the game. My attempt to automate this via a PokéAPI script was unsuccessful due to sandbox limitations, necessitating this manual data expansion.