### PR TITLE
feat: Update default player names to Silver and Gary

### DIFF
--- a/pokemon-battle/src/App.jsx
+++ b/pokemon-battle/src/App.jsx
@@ -154,7 +154,7 @@ function App() {
       });
       const newGameId = httpResponse.data.gameId;
       const actualMaxTeamSize = httpResponse.data.settings?.maxTeamSize || ABSOLUTE_MAX_TEAM_SIZE;
-      const newPlayerId = 'player1';
+      const newPlayerId = 'Silver';
 
       setGameId(newGameId);
       setPlayerId(newPlayerId);
@@ -374,7 +374,7 @@ function App() {
             <h4>Or Join Existing Game</h4>
             <div>
               <input type="text" placeholder="Enter Game ID to Join" value={joinGameIdInput} onChange={(e) => setJoinGameIdInput(e.target.value)} disabled={isLoading || isWsLoading}/>
-              <button onClick={() => joinGame(joinGameIdInput, 'player2')} disabled={isLoading || isWsLoading || !joinGameIdInput}>Join Game</button>
+              <button onClick={() => joinGame(joinGameIdInput, 'Gary')} disabled={isLoading || isWsLoading || !joinGameIdInput}>Join Game</button>
             </div>
           </div>
         )}

--- a/pokemon-battle/src/components/BattleUI.jsx
+++ b/pokemon-battle/src/components/BattleUI.jsx
@@ -84,7 +84,7 @@ function BattleUI({ gameData, playerId, onAttack, isLoading }) {
 
       {gameData.state !== 'finished' && (
         <p className="turn-indicator">
-          {gameData.turn === playerId ? "Your Turn" : (gameData.turn ? `Opponent's Turn (${opponentInfo.id.substring(0,6)}...)` : "Waiting...")}
+          {gameData.turn === playerId ? "Your Turn" : (gameData.turn ? `Opponent's Turn (${opponentInfo?.id || 'Opponent'})` : "Waiting...")}
         </p>
       )}
 
@@ -98,7 +98,7 @@ function BattleUI({ gameData, playerId, onAttack, isLoading }) {
               style={{ backgroundImage: `url(${playerActivePokemon.details.sprite})` }}
             />
           )}
-          <h3>You ({playerInfo.id.substring(0,6)}...)</h3>
+          <h3>You ({playerInfo?.id || 'Player'})</h3>
           <PartyStatusDisplay party={playerInfo.party} activePokemonIndex={playerInfo.activePokemonIndex} />
           {playerActivePokemon && playerActivePokemon.details && (
             <>
@@ -126,7 +126,7 @@ function BattleUI({ gameData, playerId, onAttack, isLoading }) {
               style={{ backgroundImage: `url(${opponentActivePokemon.details.sprite})` }}
             />
           )}
-          <h3>Opponent ({opponentInfo.id.substring(0,6)}...)</h3>
+          <h3>Opponent ({opponentInfo?.id || 'Opponent'})</h3>
           <PartyStatusDisplay party={opponentInfo.party} activePokemonIndex={opponentInfo.activePokemonIndex} />
           {opponentActivePokemon && opponentActivePokemon.details ? (
             <>


### PR DESCRIPTION
This commit changes the default player names in the application. Player 1 is now "Silver" and Player 2 is now "Gary".

Changes include:
- Modified `App.jsx` to use "Silver" when creating a new game and "Gary" when a second player joins.
- Updated `BattleUI.jsx` to display the full player names "Silver" and "Gary" in the turn indicator and player card headers, removing previous substring logic.
- Ensured player IDs are passed correctly to the backend, which already supports arbitrary string IDs.